### PR TITLE
add ag5648 documentation

### DIFF
--- a/index.md
+++ b/index.md
@@ -19,6 +19,7 @@ BISDN Linux Distribution is a custom Linux-based operating system for selected w
 
 The BISDN Linux Distribution is available for the following whitebox switch platforms:
 
+* Delta AG5648
 * Delta AG7648
 * Edgecore AS4610 series
 

--- a/setup/install_switch_image.md
+++ b/setup/install_switch_image.md
@@ -41,6 +41,7 @@ Only the following ONIE versions are tested and supported. Installation on other
 
 | Device                 | Bootloader | ONIE version    |
 |------------------------|------------|-----------------|
+| Delta AG5648           | GRUB       |[V1.00](https://github.com/DeltaProducts/ag5648/tree/master/onie_image/) |
 | Delta AG7648           | GRUB       |[2017.08.01-V1.12](https://github.com/DeltaProducts/AG7648/tree/master/onie_image/) (Build date 20181109) |
 | Edgecore AS4610-30T/P  | U-Boot     |[2016.05.00.04](https://support.edge-core.com/hc/en-us/articles/360035081033-AS4610-ONIE-v2016-05-00-04)<sup>1</sup> |
 | Edgecore AS4610-54T/P  | U-Boot     |[2016.05.00.04](https://support.edge-core.com/hc/en-us/articles/360033232494-AS4610-ONIE-v2016-05-00-04)<sup>1</sup> |


### PR DESCRIPTION
The AG5648 support is now in, so add it to the supported devices and
document the supported ONIE version.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>