### PR TITLE
added commands for checking versions

### DIFF
--- a/setup/setup_standalone.md
+++ b/setup/setup_standalone.md
@@ -39,6 +39,34 @@ systemctl start | stop | restart | enable | disable | status SERVICE.service
 
 where for example the command to show information about baseboxd would be `systemctl status baseboxd.service`.
 
+### System and component versions
+
+Checking the versions of packages, like the ones listed above, can be done using
+
+```
+sudo opkg info <package name>
+```
+
+You can also print all installed packages with their associated versions with
+```
+sudo opkg list_installed
+```
+
+For the current version of baseboxd, simply run
+```
+baseboxd --version
+```
+
+List information about the BISDN Linux release with
+```
+cat /etc/os-release
+```
+
+And information about the build date and linux kernel can be found via
+```
+uname -a
+```
+
 ### Configure a local or remote controller
 
 BISDN Linux contains the prerequisites to control the switch by either local or remote OpenFlow controllers. The default configuration is a local controller.


### PR DESCRIPTION
* Added information on how to retrieve component versions in 'system configuration', because this is where the documentation first begins using commands in BISDN Linux OS

* Added the commands 'opkg info', 'less /etc/os-release' for information on services/packages and BISDN Linux

* Additionally added 'uname -a', as it gives the Kernel version and build date which might be useful.

* Should these commands be added to the FAQs?