### PR TITLE
Update description of Ryu unsupported features

### DIFF
--- a/getting_started/configure_baseboxd.md
+++ b/getting_started/configure_baseboxd.md
@@ -82,7 +82,7 @@ sudo basebox-change-config -l ryu-manager ryu.app.ofctl_rest
 ```
 where `ryu.app.ofctl_rest` is the Ryu application. If you have a file for a custom application, please use the absolute path to the application file.
 
-Please note, that with Ryu the integration of Linux networking events is not supported, as that is a feature from baseboxd.
+Please note, that with Ryu the integration of Linux networking (netlink) events is not supported, as that is a feature from baseboxd.
 {: .label .label-yellow }
 
 #### Remote controller

--- a/getting_started/configure_baseboxd.md
+++ b/getting_started/configure_baseboxd.md
@@ -82,7 +82,7 @@ sudo basebox-change-config -l ryu-manager ryu.app.ofctl_rest
 ```
 where `ryu.app.ofctl_rest` is the Ryu application. If you have a file for a custom application, please use the absolute path to the application file.
 
-Please note, that with Ryu the integration of system networking events is not supported, as that is a feature from baseboxd.
+Please note, that with Ryu the integration of Linux networking events is not supported, as that is a feature from baseboxd.
 {: .label .label-yellow }
 
 #### Remote controller


### PR DESCRIPTION
The note about the integration of networking events not being supported
by Ryu was not very clear. Modified its content to specifically mention
that the integration with Linux networking events is not supported with
Ryu. Fixes #47

Signed-off-by: Ricardo Santos <ricardo.santos@bisdn.de>