### PR TITLE
Added links to OF-DPA

### DIFF
--- a/basebox.md
+++ b/basebox.md
@@ -87,7 +87,7 @@ Since baseboxd responds directly to the relevant netlink messages, the intended 
 
 ## OpenFlow
 
-baseboxd communicates with switches using the OpenFlow protocol. Our implementation uses the Broadcom OF-DPA flavor specifically, which is based on [OpenFlow 1.3.4](https://www.opennetworking.org/wp-content/uploads/2014/10/openflow-switch-v1.3.4.pdf). [OF-DPA 2.0 table type pattern specification](https://github.com/Broadcom-Switch/of-dpa/blob/master/OFDPAS-ETP100-R.pdf) guidelines are available. Switches compatible with Broadcom’s SDK come with the OF Agent. OF Agent is a daemon which serves the OpenFlow connection between the control plane, and the Broadcom-implemented data plane. It enforces the table type pattern specification on the switch side.
+baseboxd communicates with switches using the OpenFlow protocol. Our implementation uses the Broadcom OF-DPA flavor specifically, which is based on [OpenFlow 1.3.4](https://www.opennetworking.org/wp-content/uploads/2014/10/openflow-switch-v1.3.4.pdf). [OF-DPA 2.0 table type pattern specification](https://github.com/Broadcom-Switch/of-dpa/blob/master/OFDPAS-ETP100-R.pdf) guidelines are available. Switches compatible with Broadcom’s SDK come with the OF Agent. OF Agent is a daemon which provides the OpenFlow connection between the control plane, and the Broadcom-implemented data plane. It enforces the table type pattern specification on the switch side.
 
 ```
 +--------------+  +

--- a/basebox.md
+++ b/basebox.md
@@ -10,14 +10,11 @@ Basebox is the BISDN SDN controller bundle for data center networks with the fol
 * The BISDN Linux Distribution is a Yocto-based operating system for selected whitebox switches
 * baseboxd is a controller daemon integrating whitebox switches into Linux
 
-Based on [OpenFlow Data Path
-Abstraction (OF-DPA)](http://broadcom-switch.github.io/of-dpa/doc/html/index.html), it translates Linux netlink into switch rules. Our solution can be easily managed and flawlessly integrated in any existing Linux environment.
+Based on [OpenFlow Data Path Abstraction (OF-DPA)](http://broadcom-switch.github.io/of-dpa/doc/html/index.html), it translates Linux netlink into switch rules. Our solution can be easily managed and flawlessly integrated in any existing Linux environment.
 
 ## Architecture Overview
 
-baseboxd communicates northbound with the Linux kernel via netlink and
-southbound with the switch using OpenFlow and the OpenFlow Data Path Abstraction
-interface (OF-DPA). The Linux network stack is used to directly represent and modify the state of the switching infrastructure. For each switch port controlled by baseboxd, a Linux tap interface is created on the baseboxd host operating system.
+baseboxd communicates northbound with the Linux kernel via netlink and southbound with the switch using OpenFlow and the OpenFlow Data Path Abstraction interface (OF-DPA). The Linux network stack is used to directly represent and modify the state of the switching infrastructure. For each switch port controlled by baseboxd, a Linux tap interface is created on the baseboxd host operating system.
 
 ```
 +------------+   +

--- a/basebox.md
+++ b/basebox.md
@@ -10,11 +10,14 @@ Basebox is the BISDN SDN controller bundle for data center networks with the fol
 * The BISDN Linux Distribution is a Yocto-based operating system for selected whitebox switches
 * baseboxd is a controller daemon integrating whitebox switches into Linux
 
-Based on OpenFlow Data Path Abstraction, it translates Linux netlink into switch rules. Our solution can be easily managed and flawlessly integrated in any existing Linux environment.
+Based on [OpenFlow Data Path
+Abstraction (OF-DPA)](http://broadcom-switch.github.io/of-dpa/doc/html/index.html), it translates Linux netlink into switch rules. Our solution can be easily managed and flawlessly integrated in any existing Linux environment.
 
 ## Architecture Overview
 
-baseboxd communicates northbound with the Linux kernel via netlink and southbound with the switch using OpenFlow and the OpenFlow Data Path Abstraction interface (OFDPA). The Linux network stack is used to directly represent and modify the state of the switching infrastructure. For each switch port controlled by baseboxd, a Linux tap interface is created on the baseboxd host operating system.
+baseboxd communicates northbound with the Linux kernel via netlink and
+southbound with the switch using OpenFlow and the OpenFlow Data Path Abstraction
+interface (OF-DPA). The Linux network stack is used to directly represent and modify the state of the switching infrastructure. For each switch port controlled by baseboxd, a Linux tap interface is created on the baseboxd host operating system.
 
 ```
 +------------+   +
@@ -87,7 +90,7 @@ Since baseboxd responds directly to the relevant netlink messages, the intended 
 
 ## OpenFlow
 
-baseboxd communicates with switches using the OpenFlow protocol. Our implementation uses the Broadcom OF-DPA flavor specifically. OFDPA table type pattern specification guidelines are available. Switches compatible with Broadcom’s SDK come with the OF Agent. OF Agent is a daemon which serves the OpenFlow connection between the control plane, and the Broadcom-implemented data plane. It enforces the table type pattern specification on the switch side.
+baseboxd communicates with switches using the OpenFlow protocol. Our implementation uses the Broadcom OF-DPA flavor specifically, which uses [OpenFlow 1.3.4](https://www.opennetworking.org/wp-content/uploads/2014/10/openflow-switch-v1.3.4.pdf). [OF-DPA 2.0 table type pattern specification](https://github.com/Broadcom-Switc/of-dpa/blob/master/OFDPAS-ETP100-R.pdf) guidelines are available. Switches compatible with Broadcom’s SDK come with the OF Agent. OF Agent is a daemon which serves the OpenFlow connection between the control plane, and the Broadcom-implemented data plane. It enforces the table type pattern specification on the switch side.
 
 ```
 +--------------+  +

--- a/basebox.md
+++ b/basebox.md
@@ -87,12 +87,7 @@ Since baseboxd responds directly to the relevant netlink messages, the intended 
 
 ## OpenFlow
 
-baseboxd communicates with switches using the OpenFlow protocol. Our
-implementation uses the Broadcom OF-DPA flavor specifically, which uses
-[OpenFlow
-1.3.4](https://www.opennetworking.org/wp-content/uploads/2014/10/openflow-switch-v1.3.4.pdf).
-[OF-DPA 2.0 table type pattern
-specification](https://github.com/Broadcom-Switch/of-dpa/blob/master/OFDPAS-ETP100-R.pdf) guidelines are available. Switches compatible with Broadcom’s SDK come with the OF Agent. OF Agent is a daemon which serves the OpenFlow connection between the control plane, and the Broadcom-implemented data plane. It enforces the table type pattern specification on the switch side.
+baseboxd communicates with switches using the OpenFlow protocol. Our implementation uses the Broadcom OF-DPA flavor specifically, which is based on [OpenFlow 1.3.4](https://www.opennetworking.org/wp-content/uploads/2014/10/openflow-switch-v1.3.4.pdf). [OF-DPA 2.0 table type pattern specification](https://github.com/Broadcom-Switch/of-dpa/blob/master/OFDPAS-ETP100-R.pdf) guidelines are available. Switches compatible with Broadcom’s SDK come with the OF Agent. OF Agent is a daemon which serves the OpenFlow connection between the control plane, and the Broadcom-implemented data plane. It enforces the table type pattern specification on the switch side.
 
 ```
 +--------------+  +

--- a/basebox.md
+++ b/basebox.md
@@ -87,7 +87,12 @@ Since baseboxd responds directly to the relevant netlink messages, the intended 
 
 ## OpenFlow
 
-baseboxd communicates with switches using the OpenFlow protocol. Our implementation uses the Broadcom OF-DPA flavor specifically, which uses [OpenFlow 1.3.4](https://www.opennetworking.org/wp-content/uploads/2014/10/openflow-switch-v1.3.4.pdf). [OF-DPA 2.0 table type pattern specification](https://github.com/Broadcom-Switc/of-dpa/blob/master/OFDPAS-ETP100-R.pdf) guidelines are available. Switches compatible with Broadcom’s SDK come with the OF Agent. OF Agent is a daemon which serves the OpenFlow connection between the control plane, and the Broadcom-implemented data plane. It enforces the table type pattern specification on the switch side.
+baseboxd communicates with switches using the OpenFlow protocol. Our
+implementation uses the Broadcom OF-DPA flavor specifically, which uses
+[OpenFlow
+1.3.4](https://www.opennetworking.org/wp-content/uploads/2014/10/openflow-switch-v1.3.4.pdf).
+[OF-DPA 2.0 table type pattern
+specification](https://github.com/Broadcom-Switch/of-dpa/blob/master/OFDPAS-ETP100-R.pdf) guidelines are available. Switches compatible with Broadcom’s SDK come with the OF Agent. OF Agent is a daemon which serves the OpenFlow connection between the control plane, and the Broadcom-implemented data plane. It enforces the table type pattern specification on the switch side.
 
 ```
 +--------------+  +


### PR DESCRIPTION
* Added links to Broadcom OF-DPA 2.0 specs and manual.
* Mention that it speaks OpenFlow 1.3.4
* Change OFDPA to OF-DPA, as this seems to be the way it is written.
This fixes #43 

