### PR TITLE
remove limitation for link state reflected on tap interfaces

### DIFF
--- a/getting_started/basic_networking.md
+++ b/getting_started/basic_networking.md
@@ -24,7 +24,7 @@ $ ip link show
   ...
 ```
 
-These interfaces can be managed via the [iproute2](https://linux.die.net/man/8/ip) utilities, or any netlink supported Linux networking utility. The link state for these interfaces maps to the physical port state. Due to a limitation in the Linux kernel, the interfaces state show up as UNKNOWN or DOWN, where UNKNOWN means that the physical interface has a cable attached.
+These interfaces can be managed via the [iproute2](https://linux.die.net/man/8/ip) utilities, or any netlink supported Linux networking utility. The link state for these interfaces maps to the physical port state.
 
 **WARNING**: Despite Linux providing multiple alternatives for network configuration, iproute2 is the preferred configuration tool for BISDN Linux. The usage of other network configuration tools (e.g. ifconfig) is not covered in our documentation and might lead to unintended results.
 {: .label .label-red }


### PR DESCRIPTION
* upgrading the kernel to 5.X allows us to reflect the physical link
state on tap interfaces, so the previously mentioned limitation does not
exist anymore

Signed-off-by: Jan Klare <jan.klare@bisdn.de>