### PR TITLE
Fixed broken links and reworded one command.

### DIFF
--- a/getting_started/basic_networking.md
+++ b/getting_started/basic_networking.md
@@ -77,7 +77,7 @@ Settings for port1:
         MDI-X: Unknown
 ```
 
-**WARNING**: All link configurations shown in ethtool are currently read-only and can not be modified (meaning any changes done with ethtool will not be forwarded to the physical link, but just be shown on the tap interfaces without having any effect to the ASIC). Configuring the link speed as in [Disable auto-negotiation](.setup/setup_standalone.html#disable-auto-negotiation) however, will updates the ethtool reported speed.
+**WARNING**: All link configurations shown in ethtool are currently read-only and can not be modified (meaning any changes done with ethtool will not be forwarded to the physical link, but just be shown on the tap interfaces without having any effect to the ASIC). Configuring the link speed as in [Disable auto-negotiation](https://docs.bisdn.de/platform_configuration/auto_negotiation.html#disable-auto-negotiation) however, will updates the ethtool reported speed.
 
 ## Loopback interface
 

--- a/getting_started/basic_networking.md
+++ b/getting_started/basic_networking.md
@@ -12,7 +12,7 @@ Before starting with actually configuring the switch interfaces, you should firs
 
 BISDN Linux maps the physical ports on the switch with an abstract representation via [tuntap](https://www.kernel.org/doc/Documentation/networking/tuntap.txt) interfaces. These interfaces are special Linux software only devices, that are bound to a userspace program, specifically baseboxd for the case in BISDN Linux.
 
-If you followed the instructions from [Configure Baseboxd](configure_baseboxd.md), you should now be able to display all ports.
+If you followed the instructions from [Configure Baseboxd](/getting_started/configure_baseboxd.md), you should now be able to display all ports.
 
 ```
 $ ip link show
@@ -77,7 +77,7 @@ Settings for port1:
         MDI-X: Unknown
 ```
 
-**WARNING**: All link configurations shown in ethtool are currently read-only and can not be modified (meaning any changes done with ethtool will not be forwarded to the physical link, but just be shown on the tap interfaces without having any effect to the ASIC). Configuring the link speed as in [Disable auto-negotiation](https://docs.bisdn.de/platform_configuration/auto_negotiation.html#disable-auto-negotiation) however, will updates the ethtool reported speed.
+**WARNING**: All link configurations shown in ethtool are currently read-only and can not be modified (meaning any changes done with ethtool will not be forwarded to the physical link, but just be shown on the tap interfaces without having any effect to the ASIC). Configuring the link speed as in [Disable auto-negotiation](/platform_configuration/auto_negotiation.md#disable-auto-negotiation) however, will updates the ethtool reported speed.
 
 ## Loopback interface
 
@@ -108,7 +108,7 @@ On the server:
 root@myserver: ping 192.168.0.1
 ```
 
-To configure more complex scenarios, please refer to the [Network Configuration](../network_configuration.md) section.
+To configure more complex scenarios, please refer to the [Network Configuration](/network_configuration.md) section.
 
 
 # Persisting network configuration with systemd-networkd

--- a/getting_started/configure_baseboxd.md
+++ b/getting_started/configure_baseboxd.md
@@ -63,7 +63,7 @@ uname -a
 
 ### Configure a local or remote controller
 
-BISDN Linux contains the prerequisites to control the switch by either local or remote OpenFlow controllers. The default configuration is a local controller, with BISDN Linux currently supporting [baseboxd](https://github.com/bisdn/basebox) and [Ryu](https://osrg.github.io/ryu/).
+BISDN Linux contains the prerequisites to control the switch by either local or remote OpenFlow controllers. The default configuration is a local controller, with BISDN Linux currently supporting [baseboxd](https://github.com/bisdn/basebox) and [Ryu](https://osrg.github.io/ryu-book/en/html/index.html).
 
 Run the following scripts in the BISDN Linux shell to configure the local or remote controller.
 

--- a/getting_started/connecting_to_the_switch.md
+++ b/getting_started/connecting_to_the_switch.md
@@ -40,3 +40,5 @@ Run kermit with the following command:
 ```
 kermit .kermrc
 ```
+
+After following this page, you can continue to the [ONIE installation](install_onie.md), or if your switch already has ONIE installed then [Install BISDN Linux](install_bisdn_linux.md).

--- a/getting_started/install_bisdn_linux.md
+++ b/getting_started/install_bisdn_linux.md
@@ -55,9 +55,9 @@ to get into the ONIE CLI.
 
 Install the image via a CLI command as in the example below. All images are hosted in our [image repo](http://repo.bisdn.de/) while released images can be directly installed from [here](http://repo.bisdn.de/pub/onie/).
 
-This example installs BISDN Linux v3.0.0 for the AG7648 platform:
+This example installs BISDN Linux v3.3.0 for the AG7648 platform:
 ```
-onie-nos-install http://repo.bisdn.de.s3-eu-central-1.amazonaws.com/pub/onie/agema-ag7648/onie-bisdn-agema-ag7648-v3.0.0.bin
+onie-nos-install http://repo.bisdn.de/pub/onie/agema-ag7648/onie-bisdn-agema-ag7648-v3.3.0.bin
 ```
 
 **Note**: The ONIE CLI command can only process http URLs.
@@ -95,7 +95,7 @@ Demo Installer: platform: x86_64-agema_ag7648-r0
 After successful installation the switch will reboot itself. Once it has finished booting you should see a similar message:
 
 ```
-BISDN Linux 3.0.0 agema-ag7648 ttyUSB0
+BISDN Linux 3.3.0 agema-ag7648 ttyUSB0
 
 agema-ag7648 login:
 ```

--- a/getting_started/install_bisdn_linux.md
+++ b/getting_started/install_bisdn_linux.md
@@ -8,6 +8,9 @@ nav_order: 3
 
 Installing BISDN Linux on a whitebox switch can be done via the ONIE installer. This section shows how to connect to the switch and guides through the installation process.
 
+**WARNING**: Installing a BISDN Linux image requires a stable internet connection. To do this, please attach a network cable to the `Management` port of your switch.
+{: .label .label-red }
+
 ## Install BISDN Linux via ONIE
 
 The recommended switch image installation is done via ONIE, a tool that allows installation of Network Operating Systems on bare metal servers. This will prevent issues due to the bootloader difference between x86 and ARM platforms, where GRUB and coreboot as used, respectively.

--- a/getting_started/install_onie.md
+++ b/getting_started/install_onie.md
@@ -12,7 +12,7 @@ Check the current ONIE version of your switch by executing the following command
 onie-sysinfo -v
 ```
 
-If your switch has the supported ONIE preinstalled you can skip this part and [Install BISDN Linux](install_bisdn_linux.md) right away. In the other case you can either install a complete ONIE or upgrade an existing one.
+If your switch has the supported ONIE preinstalled you can skip this part and [Install BISDN Linux](/getting_started/install_bisdn_linux.md) right away. In the other case you can either install a complete ONIE or upgrade an existing one.
 
 ### Supported ONIE versions
 

--- a/getting_started/install_onie.md
+++ b/getting_started/install_onie.md
@@ -12,7 +12,7 @@ Check the current ONIE version of your switch by executing the following command
 onie-sysinfo -v
 ```
 
-If your switch has the supported ONIE preinstalled you can skip this part and [Install BISDN Linux](install_bisdn_linus.md) right away. In the other case you can either install a complete ONIE or upgrade an existing one.
+If your switch has the supported ONIE preinstalled you can skip this part and [Install BISDN Linux](install_bisdn_linux.md) right away. In the other case you can either install a complete ONIE or upgrade an existing one.
 
 ### Supported ONIE versions
 

--- a/index.md
+++ b/index.md
@@ -12,7 +12,7 @@ BISDN Linux Distribution is a custom Linux-based operating system for selected w
 * Based on Linux [yocto](https://www.yoctoproject.org/software-overview/downloads/) operating system
 * Software built on [OF-DPA 3.0](https://github.com/Broadcom-Switch/of-dpa)
 * Deployable via [Open Network Install Environment (ONIE)](http://onie.org/)
-* Using [of-agent](https://github.com/Broadcom-Switch/of-dpa/tree/master/src/ofagent) as the [OpenFlow](https://www.opennetworking.org/images/stories/downloads/sdn-resources/onf-specifications/openflow/openflow-switch-v1.3.5.pdf) interface
+* Using [of-agent](https://github.com/Broadcom-Switch/of-dpa/tree/master/src/ofagent) as the [OpenFlow](https://www.opennetworking.org/wp-content/uploads/2014/10/openflow-switch-v1.3.5.pdf) interface
 
 ## Compatibility
 

--- a/network_configuration/igmpmldsnooping.md
+++ b/network_configuration/igmpmldsnooping.md
@@ -1,5 +1,5 @@
 ---
-title: IMGP/MLD Snooping
+title: IGMP/MLD Snooping
 parent: Network Configuration
 ---
 
@@ -15,7 +15,7 @@ Linux implements IGMP/MLD snooping at the kernel level, and baseboxd listens for
 
 To enable multicast switching in BISDN Linux, we first have to connect the ports that will have multicast senders or receivers with a bridge. The bridge device will then receive the IGMP/MLD notifications and baseboxd will configure the new entries on the ASIC.
 
-We first create the bridge with some ports attached like described above (for instructions on how to do that, please refer to [VLAN Bridging](https://docs.bisdn.de/network_configuration/vlan_bridging.html):
+We first create the bridge with some ports attached like described above (for instructions on how to do that, please refer to [VLAN Bridging](/network_configuration/vlan_bridging.md#vlan-bridging-8021q):
 
 ```
 7: swbridge: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default qlen 1000

--- a/network_configuration/igmpmldsnooping.md
+++ b/network_configuration/igmpmldsnooping.md
@@ -15,7 +15,7 @@ Linux implements IGMP/MLD snooping at the kernel level, and baseboxd listens for
 
 To enable multicast switching in BISDN Linux, we first have to connect the ports that will have multicast senders or receivers with a bridge. The bridge device will then receive the IGMP/MLD notifications and baseboxd will configure the new entries on the ASIC.
 
-We first create the bridge with some ports attached like described above (for instructions on how to do that, please refer to [VLAN Bridging](network_configuration/vlan_bridging.html#vlan-bridging-8021q):
+We first create the bridge with some ports attached like described above (for instructions on how to do that, please refer to [VLAN Bridging](https://docs.bisdn.de/network_configuration/vlan_bridging.html):
 
 ```
 7: swbridge: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default qlen 1000

--- a/network_configuration/vlan_bridging_qinq.md
+++ b/network_configuration/vlan_bridging_qinq.md
@@ -25,7 +25,7 @@ ip link add name ${BRIDGE} type bridge vlan_filtering 1 vlan_default_pvid 1 vlan
 ip link set ${BRIDGE} up
 ```
 
-The rest of the configuration follows the same steps as the [802.1q bridging](https://docs.bisdn.de/network_configuration/vlan_bridging.html#iproute2) section.
+The rest of the configuration follows the same steps as the [802.1q bridging](/network_configuration/vlan_bridging.md#iproute2) section.
 
 ## systemd-networkd
 
@@ -44,4 +44,4 @@ VLANFiltering=1
 VLANProtocol=802.1ad
 ```
 
-The remaining configurations follow the same steps from the instructions in the [802.1q bridging](https://docs.bisdn.de/network_configuration/vlan_bridging.html#systemd-networkd) section.
+The remaining configurations follow the same steps from the instructions in the [802.1q bridging](/network_configuration/vlan_bridging.md#systemd-networkd) section.

--- a/tools/basebox-support.md
+++ b/tools/basebox-support.md
@@ -5,4 +5,9 @@ parent: Tools
 
 # basebox-support
 
-The basebox-support script enables customers to create a tar file with the current switch state. It gathers information like port status, system logs and configuration, to ease debugging and reporting errors on the switch platform. To execute properly, please run basebox-support on the switch with root privileges.
+The basebox-support script enables customers to create a tar file with the current switch state. It gathers information like port status, system logs and configuration, to ease debugging and reporting errors on the switch platform. To execute properly, please run the following command on the switch with root privileges.
+
+```
+basebox-support
+```
+

--- a/tools/ofdpa_client_tools.md
+++ b/tools/ofdpa_client_tools.md
@@ -36,7 +36,7 @@ ofdpa_acl_flow_cli.py --help
 To easily identify the installed flows, the `cookie` attribute can be set on each flow. This allows the deletion of table entries by only specifying its cookie identifier (instead of all matching attributes).
 Yet, this attribute needs to be uniquely set for each flow, as it will not be possible to delete two or more flows with the identifier.
 
-Each packet can only be matched on one flow entry, so the table flow rules need to be correctly defined. In addition, when adding/deleting table entries, the [OFDPA table type pattern (TTP) guidelines](https://github.com/Broadcom-Switch/of-dpa/blob/master/OFDPAS-ETP100-R.pdf) must be followed, as previously mentioned in the [Basebox introductory section](/basebox.html#openflow).
+Each packet can only be matched on one flow entry, so the table flow rules need to be correctly defined. In addition, when adding/deleting table entries, the [OFDPA table type pattern (TTP) guidelines](https://github.com/Broadcom-Switch/of-dpa/blob/master/OFDPAS-ETP100-R.pdf) must be followed, as previously mentioned in the [Basebox introductory section](/basebox.md#openflow).
 For example, adding the following entry will result an error:
 
 ```


### PR DESCRIPTION
* Every single link in the docs was clicked, and the broken ones were fixed.
* The onie-nos-install pointed to a (working) repo.bisdn.de link, but removing the aws part of the link looks cleaner, although both will work perfectly fine. Also updated the link from pointing to v3.0.0 to v3.3.0. Maybe there should be a latest.bin.
* On the basebox-support page, I added the command as a proper line on its own, so you can copy it like every other command refered to by the docs.