### PR TITLE
getting_started: replace non existing onie_install with working command

### DIFF
--- a/getting_started/install_bisdn_linux.md
+++ b/getting_started/install_bisdn_linux.md
@@ -21,7 +21,7 @@ On switches using U-Boot bootloader:
 Interrupt the U-Boot boot countdown by pressing any key and enter
 
 ```
-run onie_install
+setenv onie_boot_reason install && boot
 ```
 
 to install a switch image. To remove the image, enter


### PR DESCRIPTION
While onie_rescue and onie_uninstall exist, there is no onie_install
script. So replace the line with the appropriate equivalent command to
go into ONIE nos install mode.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>