### PR TITLE
Add support for testing using container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# This Dockerfile can be used to test the website.
+
+# Usage:
+# - docker build -t jekyll .
+# - docker run --rm -it -v $(pwd):/website -p4000:4000 jekyll
+#   Alternatively, when using podman:
+#   podman run --rm -it -v $(pwd):/website:O -p4000:4000 jekyll
+# - Point browser to http://127.0.0.1:4000/
+
+FROM fedora:33
+
+# Preinstall build requirements for jekyll
+RUN dnf install -y ruby-devel redhat-rpm-config g++ zlib-devel
+
+# Install jekyll matching the repo's Gemfile.lock
+COPY Gemfile Gemfile.lock /
+RUN bundle install
+
+# Serve site on all container interfaces
+RUN echo "bundle exec jekyll serve --host 0.0.0.0 --port 4000" >> entrypoint.sh
+
+# Run entrypoint.sh from within the website directory
+WORKDIR /website
+ENTRYPOINT ["bash", "/entrypoint.sh"]
+EXPOSE 4000

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@
 $ cd ./bisdn.github.io
 ```
 
+At this point, you can decide to either install the required software on the
+host (section "Host installation") or in a container (section "Using
+container").
+
+#### Host installation
+
 3. Make sure ruby is installed 
 
 ```
@@ -42,5 +48,46 @@ $ bundle exec jekyll serve
 ```
 $ http://localhost:4000
 ```
+
+#### Using container
+
+3. Build container image
+
+```
+$ docker build -t jekyll .
+```
+
+4. Run container
+
+On most platforms, the following command is sufficient to have jekyll serve the
+website on the host's http://localhost:4000:
+
+```
+$ docker run --rm -it -v $(pwd):/website -p4000:4000 jekyll
+```
+
+If you are running on a platform with SELinux enabled, you may get a
+"Permission denied" error. There are several solutions for this as
+outlined below.
+
+If you are using podman, you can try mounting the bisdn.github.io directory as
+an overlay (the container does not need to make any changes to the directory,
+let alone permanent ones) using the ':O' suffix.
+
+```
+$ podman run --rm -it -v $(pwd):/website:O -p4000:4000 jekyll
+```
+
+Alternatively, you can disable SELinux label confinement:
+
+```
+$ docker run --rm -it --security-opt label=disable \
+  -v $(pwd):/website -p4000:4000 jekyll
+```
+
+If you are using docker, there is also the option of having docker relabel the
+directory (using the :Z option instead of the :O option mentioned above). Note
+that docker will remove any existing label and _not_ remove the label it set
+once the container stops running.
 
 ## Usage


### PR DESCRIPTION
This changeset adds a documented Dockerfile which can be used for testing the website locally. This is, for instance, useful for testing the website's internal links.