### PR TITLE
De-sync of ports in older versions of BISDN linux

### DIFF
--- a/limitations.md
+++ b/limitations.md
@@ -62,3 +62,19 @@ OF-DPA will miss any physical link state changes happening.
 
 Any port state changes happening between the initial read out and the
 successful registration of the handler will be missed.
+
+The port sync issue may be identified by the link inability to set a port up
+even though the port is connected. Using port2 as an example we run
+
+```
+ip link set port2 up
+ip link show port2
+
+port2: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc pfifo_fast state DOWN mode DEFAULT group default qlen 1000
+```
+
+Which shows ``NO-CARRIER`` and ``state DOWN``. You can resolve the issue by
+using the OF-DPA api to first disable and then enable the port again.
+
+``client_drivshell port 2 Enable=false``
+``client_drivshell port 2 Enable=true``

--- a/limitations.md
+++ b/limitations.md
@@ -63,7 +63,7 @@ OF-DPA will miss any physical link state changes happening.
 Any port state changes happening between the initial read out and the
 successful registration of the handler will be missed.
 
-The port sync issue may be identified by the link inability to set a port up
+The port sync issue may be identified by the link's inability to set a port up
 even though the port is connected. Using port2 as an example we run
 
 ```

--- a/limitations.md
+++ b/limitations.md
@@ -53,7 +53,7 @@ As documented in the currently open upstream FRR issue [#7299](https://github.co
 ## Ports connected during boot may sometimes show as having no carrier in Linux
 
 All releases of BISDN Linux prior to version 3.7.3 suffer from an issue where
-the port state might end up out of sync
+the port state might end up out of sync.
 
 This is caused by a race in OF-DPA, where OF-DPA first initializes ports with
 their current state, and only then registers the linkscan handler, which

--- a/limitations.md
+++ b/limitations.md
@@ -49,3 +49,17 @@ In all of these cases forcing the port on the switch to the desired speed works 
 ## Missing routes for EIGRP with flapping ports
 
 As documented in the currently open upstream FRR issue [#7299](https://github.com/FRRouting/frr/issues/7299), some routes may get dropped or are not correctly received when ports are flapping during EIGRP session establishment. For now, we recommend the workaround of restarting FRR after all ports are up if this behavior is observed.
+
+## Port state sync issue on boot caused by OF-DPA
+
+All releases of BISDN Linux prior to version 4.0 suffer from an issue where
+port state might end up out of sync if network configuration is applied during,
+or shortly after, booting up, e.g. using systemd-networkd.
+
+This is caused by a race in OF-DPA, where OF-DPA first initializes ports with
+their current state, and only then registers notifications about port state
+changes.
+
+Any port state changes happening between the initial read out and the
+successful registration of the handler will be missed.
+

--- a/limitations.md
+++ b/limitations.md
@@ -50,7 +50,7 @@ In all of these cases forcing the port on the switch to the desired speed works 
 
 As documented in the currently open upstream FRR issue [#7299](https://github.com/FRRouting/frr/issues/7299), some routes may get dropped or are not correctly received when ports are flapping during EIGRP session establishment. For now, we recommend the workaround of restarting FRR after all ports are up if this behavior is observed.
 
-## Port state sync issue on boot caused by OF-DPA
+## Ports connected during boot may sometimes show as having no carrier in Linux
 
 All releases of BISDN Linux prior to version 4.0 suffer from an issue where
 the port state might end up out of sync

--- a/limitations.md
+++ b/limitations.md
@@ -53,13 +53,12 @@ As documented in the currently open upstream FRR issue [#7299](https://github.co
 ## Port state sync issue on boot caused by OF-DPA
 
 All releases of BISDN Linux prior to version 4.0 suffer from an issue where
-port state might end up out of sync if network configuration is applied during,
-or shortly after, booting up. This occurs, for instance, when systemd-networkd
-is used to configure network interfaces.
+the port state might end up out of sync
 
 This is caused by a race in OF-DPA, where OF-DPA first initializes ports with
 their current state, and only then registers the linkscan handler, which
-is responsible for updating OF-DPA's port state.
+is responsible for updating OF-DPA's port state. This creates a window where
+OF-DPA will miss any physical link state changes happening.
 
 Any port state changes happening between the initial read out and the
 successful registration of the handler will be missed.

--- a/limitations.md
+++ b/limitations.md
@@ -54,12 +54,12 @@ As documented in the currently open upstream FRR issue [#7299](https://github.co
 
 All releases of BISDN Linux prior to version 4.0 suffer from an issue where
 port state might end up out of sync if network configuration is applied during,
-or shortly after, booting up, e.g. using systemd-networkd.
+or shortly after, booting up. This occurs, for instance, when systemd-networkd
+is used to configure network interfaces.
 
 This is caused by a race in OF-DPA, where OF-DPA first initializes ports with
-their current state, and only then registers notifications about port state
-changes.
+their current state, and only then registers the linkscan handler, which
+is responsible for updating OF-DPA's port state.
 
 Any port state changes happening between the initial read out and the
 successful registration of the handler will be missed.
-

--- a/limitations.md
+++ b/limitations.md
@@ -52,7 +52,7 @@ As documented in the currently open upstream FRR issue [#7299](https://github.co
 
 ## Ports connected during boot may sometimes show as having no carrier in Linux
 
-All releases of BISDN Linux prior to version 4.0 suffer from an issue where
+All releases of BISDN Linux prior to version 3.7.3 suffer from an issue where
 the port state might end up out of sync
 
 This is caused by a race in OF-DPA, where OF-DPA first initializes ports with


### PR DESCRIPTION
* Added mention of the port state sync issue due to OF-DPA on bootup

Signed-off-by: Hilmar Magnusson <hilmar.magnusson@bisdn.de>