### PR TITLE
dhcp multicast

### DIFF
--- a/getting_started/configure_baseboxd.md
+++ b/getting_started/configure_baseboxd.md
@@ -108,8 +108,14 @@ baseboxd uses a file to store configuration data like log level and OpenFlow por
 ```
 ### Configuration options for baseboxd
 #
+# Enable multicast supporrt:
+# FLAGS_multicast=true
+#
 # Listening port:
 # FLAGS_port=6653
+#
+# gRPC listening port:
+# FLAGS_ofdpa_grpc_port=50051
 
 ### glog
 #

--- a/limitations.md
+++ b/limitations.md
@@ -12,13 +12,11 @@ spanning tree protocols STP, RSTP and MSTP.
 ## No VxLAN support on Accton AS4610
 The Broadcom Switch ASIC used in Accton AS4610 does not support VxLAN.
 
-## DHCP issue on Accton-AS 4610
+## DHCP packets not forwarded correctly
 
-There is a bug that causes DHCP packets to not get forwarded properly, and this
-issue may appear in as little as a few minutes or take several days of switch
-uptime. The only known permanent fix for this is to disable multicast by
-setting ''FLAGS_multicast=false'' in the [baseboxd configuration file](../getting_started/configure_baseboxd.html#setup-baseboxd).
-Rebooting the switch will only temporarily resolve the issue.
+The switch may sometimes stop forwarding DHCP packets correctly. uptime. The
+only known workaround (starting with BISDN Linux v4.0) is to disable multicast
+by setting ''FLAGS_multicast=false'' in the [baseboxd configuration file](../getting_started/configure_baseboxd.html#setup-baseboxd).
 
 ## Agema-5648 PCIe Bus error
 

--- a/limitations.md
+++ b/limitations.md
@@ -14,9 +14,9 @@ The Broadcom Switch ASIC used in Accton AS4610 does not support VxLAN.
 
 ## DHCP packets not forwarded correctly
 
-The switch may sometimes stop forwarding DHCP packets correctly. uptime. The
+The switch may sometimes stop forwarding DHCP packets correctly. The
 only known workaround (starting with BISDN Linux v4.0) is to
-[disable multicast](network_configuration/igmpmldsnooping.md#enablingdisabling-multicast)
+[disable multicast](network_configuration/igmpmldsnooping.md#enablingdisabling-multicast).
 
 ## Agema-5648 PCIe Bus error
 

--- a/limitations.md
+++ b/limitations.md
@@ -15,9 +15,9 @@ The Broadcom Switch ASIC used in Accton AS4610 does not support VxLAN.
 ## DHCP issue on Accton-AS 4610
 
 There is a bug that causes DHCP packets to not get forwarded properly, and this
-issue generally takes several days of switch uptime before appearing. The only
-known permanent fix for this is to disable multicast by setting
-''FLAGS_multicast=false'' in the [baseboxd configuration file](../getting_started/configure_baseboxd.html#setup-baseboxd).
+issue may appear in as little as a few minutes or take several days of switch
+uptime. The only known permanent fix for this is to disable multicast by
+setting ''FLAGS_multicast=false'' in the [baseboxd configuration file](../getting_started/configure_baseboxd.html#setup-baseboxd).
 Rebooting the switch will only temporarily resolve the issue.
 
 ## Agema-5648 PCIe Bus error

--- a/limitations.md
+++ b/limitations.md
@@ -12,6 +12,14 @@ spanning tree protocols STP, RSTP and MSTP.
 ## No VxLAN support on Accton AS4610
 The Broadcom Switch ASIC used in Accton AS4610 does not support VxLAN.
 
+## DHCP issue on Accton-AS 4610
+
+There is a bug that causes DHCP packets to not get forwarded properly, and this
+issue generally takes several days of switch uptime before appearing. The only
+known permanent fix for this is to disable multicast by setting
+''FLAGS_multicast=false'' in the [baseboxd configuration file](../getting_started/configure_baseboxd.html#setup-baseboxd).
+Rebooting the switch will only temporarily resolve the issue.
+
 ## Agema-5648 PCIe Bus error
 
 **A workaround preventing the issue has been implemented in BISDN Linux 3.5.2.**

--- a/limitations.md
+++ b/limitations.md
@@ -15,8 +15,8 @@ The Broadcom Switch ASIC used in Accton AS4610 does not support VxLAN.
 ## DHCP packets not forwarded correctly
 
 The switch may sometimes stop forwarding DHCP packets correctly. uptime. The
-only known workaround (starting with BISDN Linux v4.0) is to disable multicast
-by setting ''FLAGS_multicast=false'' in the [baseboxd configuration file](../getting_started/configure_baseboxd.html#setup-baseboxd).
+only known workaround (starting with BISDN Linux v4.0) is to
+[disable multicast](network_configuration/igmpmldsnooping.md#enablingdisabling-multicast)
 
 ## Agema-5648 PCIe Bus error
 

--- a/limitations.md
+++ b/limitations.md
@@ -16,7 +16,7 @@ The Broadcom Switch ASIC used in Accton AS4610 does not support VxLAN.
 
 The switch may sometimes stop forwarding DHCP packets correctly. The
 only known workaround (starting with BISDN Linux v4.0) is to
-[disable multicast](network_configuration/igmpmldsnooping.md#enablingdisabling-multicast).
+[disable IGMP/MLD Snooping](network_configuration/igmpmldsnooping.md#enablingdisablingigmpmldsnooping).
 
 ## Agema-5648 PCIe Bus error
 

--- a/network_configuration/igmpmldsnooping.md
+++ b/network_configuration/igmpmldsnooping.md
@@ -1,5 +1,5 @@
 ---
-title: IGMP/MLD Snooping
+title: IGMP/MLD Snooping (Multicast)
 parent: Network Configuration
 ---
 
@@ -8,6 +8,10 @@ parent: Network Configuration
 BISDN Linux itself is capable of acting as a layer 2 multicast switch and with the help of frr can also be turned into a full fledged multicast router.
 
 In multicast switches and routers, the multicast group membership is managed by utilising the Internet Group Management Protocol (IGMP) or Multicast Listener Discovery (MLD). Both protocols report the interest of a host to receive a data stream, IGMP for IPv4 and MLD for IPv6 traffic. IGMP and MLD snooping is a technique that allows multicast switches to maintain a map of which links need to receive IP multicast transmissions.
+
+## Enabling/disabling multicast
+
+Multicast is enabled by default, but can be disabled by setting ''FLAGS_multicast=false'' in the [baseboxd configuration file](../getting_started/configure_baseboxd.html#setup-baseboxd).
 
 ## Linux Configuration
 

--- a/network_configuration/igmpmldsnooping.md
+++ b/network_configuration/igmpmldsnooping.md
@@ -9,7 +9,7 @@ BISDN Linux itself is capable of acting as a layer 2 multicast switch and with t
 
 In multicast switches and routers, the multicast group membership is managed by utilising the Internet Group Management Protocol (IGMP) or Multicast Listener Discovery (MLD). Both protocols report the interest of a host to receive a data stream, IGMP for IPv4 and MLD for IPv6 traffic. IGMP and MLD snooping is a technique that allows multicast switches to maintain a map of which links need to receive IP multicast transmissions.
 
-## Enabling/disabling multicast
+## Enabling/disabling IGMP/MLD Snooping
 
 Multicast is enabled by default, but can be disabled by setting ''FLAGS_multicast=false'' in the [baseboxd configuration file](../getting_started/configure_baseboxd.html#setup-baseboxd).
 


### PR DESCRIPTION
Added section about disabling multicast, with a link to the section refering to basebox configuration file.
Default configuration file was updated to reflect the latest version.
Limitations page now contains a section describing the DHCP issue, and suggestions for how to deal with it.