### PR TITLE
RFC: move fixable and fixed issues out from limitations into their own lists

### DIFF
--- a/limitations_and_known_issues.md
+++ b/limitations_and_known_issues.md
@@ -3,45 +3,15 @@ title: Limitations and known issues
 nav_order: 9
 ---
 
-# Limitations and known issues
-
-## No support for VXLAN and STP on bonded interfaces
-Currently VXLAN is not supported on bonded interfaces. The same is true for the
-spanning tree protocols STP, RSTP and MSTP.
+# Limitations
 
 ## No VxLAN support on Accton AS4610
 The Broadcom Switch ASIC used in Accton AS4610 does not support VxLAN.
-
-## DHCP packets not forwarded correctly
-
-In BISDN Linux prior to the release 4.1, switches would sometimes stop
-forwarding DHCP packets correctly due to an issue in handling multicast
-subscriptions within OF-DPA. The only known workaround (starting with BISDN
-Linux v4.0) is to [disable IGMP/MLD Snooping](network_configuration/igmpmldsnooping.md#enablingdisablingigmpmldsnooping).
-To avoid the issue completely, we recommend upgrading to release 4.1 or higher.
-
-## Celestica Questone 2A port LEDs do not light up
-
-In BISDN Linux prior to the release 4.1 the LEDs on Celestica Questone 2A ports do not light up when a link is established.
 
 ## Celestica Questone 2A fans spinning at 100%
 
 Please ensure that both PSUs are connected and have power. The switch will fall back to a fail-safe mode with all fans spinning at 100% if only one of the PSUs is available.
 
-## Agema-5648 PCIe Bus error
-
-**A workaround preventing the issue has been implemented in BISDN Linux 3.5.2.**
-
-The driver for the PCI bus may report an error leading to the controller not receiving any traffic and causing the platform to completely stop working until restarted. This is a sporadic bug and can be verified by running dmesg where the following logs are available to confirm the presence of the error.
-
-```
-[...] pcieport 0000:00:01.0: AER: Uncorrected (Non-Fatal) error received: 0000:01:00.0
-[...] linux-kernel-bde 0000:01:00.0: AER: PCIe Bus Error: severity=Uncorrected (Non-Fatal), type=Transaction Layer, (Requester ID)
-[...] linux-kernel-bde 0000:01:00.0: AER:   device [14e4:b967] error status/mask=00004000/00000000
-[...] linux-kernel-bde 0000:01:00.0: AER:    [14] CmpltTO                (First)
-[...] pcieport 0000:00:01.0: AER: Device recovery successful
-```
-The message `AER: Device recovery successful` shown above is misleading, since the Error can only be resolved by fully rebooting the switch itself.
 ## Table size differences
 
 There might be discrepancies in the maximum number of entries in the unicast routing table (30) announced by [of-dpa](https://github.com/Broadcom-Switch/of-dpa) and how many it accepts.
@@ -71,9 +41,44 @@ Depending on the switch and the link partner, we have observed the following beh
 
 In all of these cases forcing the port on the switch to the desired speed works as expected.
 
+# Open issues
+
+## No support for VXLAN and STP on bonded interfaces
+Currently VXLAN is not supported on bonded interfaces. The same is true for the
+spanning tree protocols STP, RSTP and MSTP.
+
 ## Missing routes for EIGRP with flapping ports
 
 As documented in the currently open upstream FRR issue [#7299](https://github.com/FRRouting/frr/issues/7299), some routes may get dropped or are not correctly received when ports are flapping during EIGRP session establishment. For now, we recommend the workaround of restarting FRR after all ports are up if this behavior is observed.
+
+# Resolved issues
+
+## DHCP packets not forwarded correctly
+
+In BISDN Linux prior to the release 4.1, switches would sometimes stop
+forwarding DHCP packets correctly due to an issue in handling multicast
+subscriptions within OF-DPA. The only known workaround (starting with BISDN
+Linux v4.0) is to [disable IGMP/MLD Snooping](network_configuration/igmpmldsnooping.md#enablingdisablingigmpmldsnooping).
+To avoid the issue completely, we recommend upgrading to release 4.1 or higher.
+
+## Celestica Questone 2A port LEDs do not light up
+
+In BISDN Linux prior to the release 4.1 the LEDs on Celestica Questone 2A ports do not light up when a link is established.
+
+## Agema-5648 PCIe Bus error
+
+**A workaround preventing the issue has been implemented in BISDN Linux 3.5.2.**
+
+The driver for the PCI bus may report an error leading to the controller not receiving any traffic and causing the platform to completely stop working until restarted. This is a sporadic bug and can be verified by running dmesg where the following logs are available to confirm the presence of the error.
+
+```
+[...] pcieport 0000:00:01.0: AER: Uncorrected (Non-Fatal) error received: 0000:01:00.0
+[...] linux-kernel-bde 0000:01:00.0: AER: PCIe Bus Error: severity=Uncorrected (Non-Fatal), type=Transaction Layer, (Requester ID)
+[...] linux-kernel-bde 0000:01:00.0: AER:   device [14e4:b967] error status/mask=00004000/00000000
+[...] linux-kernel-bde 0000:01:00.0: AER:    [14] CmpltTO                (First)
+[...] pcieport 0000:00:01.0: AER: Device recovery successful
+```
+The message `AER: Device recovery successful` shown above is misleading, since the Error can only be resolved by fully rebooting the switch itself.
 
 ## Ports connected during boot may sometimes show as having no carrier in Linux
 

--- a/limitations_and_known_issues.md
+++ b/limitations_and_known_issues.md
@@ -26,7 +26,6 @@ baseboxd is not compatible with [Linux namespaces](http://man7.org/linux/man-pag
 
 The script onie-bisdn-upgrade allows to use static IP configuration instead of DHCP. However, using the current ONIE installer, there is no route set towards the gateway, so images outside the configured network or, when using the “current” option, outside the switch management network (‘enp0s20f0’) can not be pulled and installed automatically.
 
-
 ## Enabling auto-negotiation on ports may not work as expected
 
 Depending on the switch and the link partner, we have observed the following behaviors:
@@ -44,16 +43,23 @@ In all of these cases forcing the port on the switch to the desired speed works 
 # Open issues
 
 ## No support for VXLAN and STP on bonded interfaces
+
+Affected versions: 3.5 - current
+
 Currently VXLAN is not supported on bonded interfaces. The same is true for the
 spanning tree protocols STP, RSTP and MSTP.
 
 ## Missing routes for EIGRP with flapping ports
+
+Affected versions: 3.0 - current
 
 As documented in the currently open upstream FRR issue [#7299](https://github.com/FRRouting/frr/issues/7299), some routes may get dropped or are not correctly received when ports are flapping during EIGRP session establishment. For now, we recommend the workaround of restarting FRR after all ports are up if this behavior is observed.
 
 # Resolved issues
 
 ## DHCP packets not forwarded correctly
+
+Affected versions: 3.0 - 4.0
 
 In BISDN Linux prior to the release 4.1, switches would sometimes stop
 forwarding DHCP packets correctly due to an issue in handling multicast
@@ -63,11 +69,13 @@ To avoid the issue completely, we recommend upgrading to release 4.1 or higher.
 
 ## Celestica Questone 2A port LEDs do not light up
 
+Affected versions: 4.0
+
 In BISDN Linux prior to the release 4.1 the LEDs on Celestica Questone 2A ports do not light up when a link is established.
 
 ## Agema-5648 PCIe Bus error
 
-**A workaround preventing the issue has been implemented in BISDN Linux 3.5.2.**
+Affected versions: 3.0 - 3.5.1
 
 The driver for the PCI bus may report an error leading to the controller not receiving any traffic and causing the platform to completely stop working until restarted. This is a sporadic bug and can be verified by running dmesg where the following logs are available to confirm the presence of the error.
 
@@ -81,6 +89,8 @@ The driver for the PCI bus may report an error leading to the controller not rec
 The message `AER: Device recovery successful` shown above is misleading, since the Error can only be resolved by fully rebooting the switch itself.
 
 ## Ports connected during boot may sometimes show as having no carrier in Linux
+
+Affected versions: 3.0 - 3.7.2
 
 All releases of BISDN Linux prior to version 3.7.3 suffer from an issue where
 the port state might end up out of sync.

--- a/limitations_and_known_issues.md
+++ b/limitations_and_known_issues.md
@@ -1,9 +1,9 @@
 ---
-title: Limitations
+title: Limitations and known issues
 nav_order: 9
 ---
 
-# Limitations
+# Limitations and known issues
 
 ## No support for VXLAN and STP on bonded interfaces
 Currently VXLAN is not supported on bonded interfaces. The same is true for the


### PR DESCRIPTION
We currently have a mix of hard limitations we cannot do anything about, code issues we might/will tackle, and code issues we did tackle in the limitations page.

Having fixed and open issues in a page called limitations might be a bit unexpected, so let's rename the page to also say they include known issues. To then make them a bit more accessible, split them into three lists; limitations which we cannot fix, open issues which aren't fixed, and resolved issues with a list of versions which are affected by it.