### PR TITLE
the systemd-networkd config dir is named /etc/systemd/network/

### DIFF
--- a/network_configuration/stp.md
+++ b/network_configuration/stp.md
@@ -30,7 +30,7 @@ An STP-enabled bridge can be created using iproute2 with the following command:
 ip link add name swbridge type bridge vlan_filtering 1 stp_state 1
 ```
 
-or by copying following systemd-networkd configuration files into the /etc/systemd/networkd directory and restarting the `systemd-networkd` systemd-service.
+or by copying following systemd-networkd configuration files into the /etc/systemd/network directory and restarting the `systemd-networkd` systemd-service.
 ```
 10-swbridge.netdev:
 

--- a/network_configuration/vlan_bridging.md
+++ b/network_configuration/vlan_bridging.md
@@ -63,7 +63,7 @@ ip link set ${PORTA} nomaster
 
 ## systemd-networkd
 
-The configuration with systemd-networkd can be done with the following files, under the /etc/systemd/networkd directory.
+The configuration with systemd-networkd can be done with the following files, under the /etc/systemd/network directory.
 
 ```
 10-swbridge.netdev:
@@ -186,7 +186,7 @@ ip link del swbridge
 ## systemd-networkd
 
 The configuration with systemd-networkd can be done by placing the following files,
-under the /etc/systemd/networkd directory. The first line of the snippet is
+under the /etc/systemd/network directory. The first line of the snippet is
 the file name.
 The first two files create the bridge and add VLAN 2 and 3 to it, completely
 analogous to ``iproute2``

--- a/network_configuration/vxlan.md
+++ b/network_configuration/vxlan.md
@@ -59,7 +59,7 @@ The configuration with systemd-networkd can be done with the following files.
 
 Create bridge ``swbridge`` with no ``DefaultPVID``.
 
-`switch-1 /etc/systemd/networkd/20-swbridge.netdev`
+`switch-1 /etc/systemd/network/20-swbridge.netdev`
 ```
 [NetDev]
 Name=swbridge
@@ -72,7 +72,7 @@ DefaultPVID=none
 
 Tag ``swbridge`` with ``VLAN=300`` and set it up.
 
-`switch-1 /etc/systemd/networkd/20-swbridge.network`
+`switch-1 /etc/systemd/network/20-swbridge.network`
 ```
 [Match]
 Name=swbridge
@@ -83,7 +83,7 @@ VLAN=300
 
 Add VLAN tag ``VLAN=300`` on ``port2`` incoming traffic, untag the outgoing one, attach it to ``swbridge`` and set it up.
 
-`switch-1 /etc/systemd/networkd/10-port2.network`
+`switch-1 /etc/systemd/network/10-port2.network`
 ```
 [Match]
 Name=port2
@@ -98,7 +98,7 @@ EgressUntagged=300
 
 Add ip address 192.168.0.1/24 to ``port54``, define it as underlying interface for netdev vxlan50000 (created below) and set it up.
 
-`switch-1 /etc/systemd/networkd/10-port54.network`
+`switch-1 /etc/systemd/network/10-port54.network`
 ```
 [Match]
 Name=port54
@@ -111,7 +111,7 @@ Address=192.168.0.1/24
 Create netdev ``vxlan50000`` for VXLAN with the VNI 50000 and set local and remote VXLAN Tunnel
 Endpoints(VTEPs).
 
-`switch-1 /etc/systemd/networkd/300-vxlan50000.netdev`
+`switch-1 /etc/systemd/network/300-vxlan50000.netdev`
 ```
 [NetDev]
 Name=vxlan50000
@@ -135,7 +135,7 @@ set systemd will use the default Linux kernel value 8472.
 which means that every remote VTEP must use ``DestinationPort``=4789.
 {: .label .label-yellow }
 
-`switch-1 /etc/systemd/networkd/300-vxlan50000.network`
+`switch-1 /etc/systemd/network/300-vxlan50000.network`
 ```
 [Match]
 Name=vxlan50000
@@ -152,7 +152,7 @@ The configuration files for ``switch2`` are identical to those of ``switch1``
 with the execption that the IPv4 addresses for the VTEP, Remote and Local will
 switch. Therefore the files below are shown without additional explanation.
 
-`switch-2 /etc/systemd/networkd/20-swbridge.netdev`
+`switch-2 /etc/systemd/network/20-swbridge.netdev`
 ```
 [NetDev]
 Name=swbridge
@@ -163,7 +163,7 @@ VLANFiltering=1
 DefaultPVID=none
 ```
 
-`switch-2 /etc/systemd/networkd/20-swbridge.network`
+`switch-2 /etc/systemd/network/20-swbridge.network`
 ```
 [Match]
 Name=swbridge
@@ -172,7 +172,7 @@ Name=swbridge
 VLAN=300
 ```
 
-`switch-2 /etc/systemd/networkd/10-port2.network`
+`switch-2 /etc/systemd/network/10-port2.network`
 ```
 [Match]
 Name=port2
@@ -185,7 +185,7 @@ PVID=300
 EgressUntagged=300
 ```
 
-`switch-2 /etc/systemd/networkd/10-port54.network`
+`switch-2 /etc/systemd/network/10-port54.network`
 ```
 [Match]
 Name=port54
@@ -195,7 +195,7 @@ VXLAN=vxlan50000
 Address=192.168.0.2/24
 ```
 
-`switch-2 /etc/systemd/networkd/300-vxlan50000.netdev`
+`switch-2 /etc/systemd/network/300-vxlan50000.netdev`
 ```
 [NetDev]
 Name=vxlan50000
@@ -208,7 +208,7 @@ Local=192.168.0.2
 Remote=192.168.0.1
 ```
 
-`switch-2 /etc/systemd/networkd/300-vxlan50000.network`
+`switch-2 /etc/systemd/network/300-vxlan50000.network`
 ```
 [Match]
 Name=vxlan50000


### PR DESCRIPTION
* replace /etc/systemd/networkd/ with /etc/systemd/network/ in all files

Signed-off-by: Jan Klare <jan.klare@bisdn.de>