### PR TITLE
build(deps): bump jekyll-commonmark-ghpages from 0.1.6 to 0.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,7 @@ GEM
       jekyll (= 3.9.0)
       jekyll-avatar (= 0.7.0)
       jekyll-coffeescript (= 1.1.1)
-      jekyll-commonmark-ghpages (= 0.1.6)
+      jekyll-commonmark-ghpages (= 0.2.0)
       jekyll-default-layout (= 0.1.4)
       jekyll-feed (= 0.15.1)
       jekyll-gist (= 1.5.0)


### PR DESCRIPTION
Updates the commonmarker dependency to latest, resolving the integer
overflow issue in cmark-gfm used by commonmarker.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>