### PR TITLE
Netlink buffer limitation update

### DIFF
--- a/limitations_and_known_issues.md
+++ b/limitations_and_known_issues.md
@@ -50,13 +50,6 @@ In all of these cases forcing the port on the switch to the desired speed works 
 
 # Open issues
 
-## Socket receive buffer size causes baseboxd to miss netlink events
-
-Affected versions: 3.0 - current
-
-BISDN Linux increases `net.core.rmem_default` while leaving `net.core.rmem_max` at the default value which is lower than the new `net.core.rmem_default`. Because baseboxd creates its netlink read buffer based on the max value, a large burst of netlink events may result in netlink messages being lost, with baseboxd failing to fully synchronize the ASIC state with the kernel state.
-The solution is to add the line `net.core.rmem_max=8388608` to `/etc/sysctl.d/20-network-io.conf`.
-
 ## Ports default to no FEC even if the SFP module type inserted requires FEC
 
 Affected versions: 3.0 - current
@@ -92,6 +85,13 @@ Affected versions: 4.4 - current
 The Accton AS4630-54PE platform LEDs for the SFP interfaces are always stuck on white.
 
 # Resolved issues
+
+## Socket receive buffer size causes baseboxd to miss netlink events
+
+Affected versions: 3.0 - 4.5
+
+BISDN Linux increases `net.core.rmem_default` while leaving `net.core.rmem_max` at the default value which is lower than the new `net.core.rmem_default`. Because baseboxd creates its netlink read buffer based on the max value, a large burst of netlink events may result in netlink messages being lost, with baseboxd failing to fully synchronize the ASIC state with the kernel state.
+The solution is to add the line `net.core.rmem_max=8388608` to `/etc/sysctl.d/20-network-io.conf`.
 
 ## MAC addresses of BCM KNET interfaces change on every boot
 

--- a/limitations_and_known_issues.md
+++ b/limitations_and_known_issues.md
@@ -78,7 +78,7 @@ As documented in the currently open upstream FRR issue [#7299](https://github.co
 ## Accton-AS4630-54PE: Link speed setting for interfaces connected with optical modules
 
 Affected versions: 4.4 - current
-  
+
 The Accton AS4630-54PE platform may not properly establish a link when using optical 100G modules. As a workaround, add the following configuration into `/etc/ofdpa/rc.soc`.
 
 ```


### PR DESCRIPTION
The netlink buffer issue was fixed in the [v4.6.0 release](http://repo.bisdn.de.s3-eu-central-1.amazonaws.com/pub/onie/accton-as5835-54x/onie-bisdn-accton-as5835-54x-v4.6.0-releasenotes.txt)

So 4.5 is the last version with this issue.
Also removed some trailing spaces in a separate commit.