### PR TITLE
Fix broken links and update link text

### DIFF
--- a/docker_container.md
+++ b/docker_container.md
@@ -29,8 +29,8 @@ sudo systemctl enable docker
 sudo systemctl start docker
 ```
 
-To learn how to work with docker containers, please refer to the official docker
-documentation available [here](https://docs.docker.com/get-started/).
+To learn how to work with docker containers, please refer to the
+[official docker documentation](https://docs.docker.com/get-started/).
 
 If you want to run a simple nginx web server, you can ssh to the switch and run:
 

--- a/getting_started/configure_baseboxd.md
+++ b/getting_started/configure_baseboxd.md
@@ -134,7 +134,7 @@ GLOG_logtostderr=1
 
 We use the [Google Logging Library](https://hpc.nih.gov/development/glog.html) for logging. This includes the [GLOG_vmodule](https://hpc.nih.gov/development/glog.html#verbose) that allows you to set the log level for specific sub-modules.
 
-For example, if you want to set the log levels for the [https://github.com/bisdn/basebox/blob/master/src/netlink/cnetlink.h](cnetlink) and [https://github.com/bisdn/basebox/blob/master/src/netlink/nl_bridge.h](nl_bridge) sub-modules to 3 and 2, respectively, simply add the following line to the configuration file:
+For example, if you want to set the log levels for the [cnetlink](https://github.com/bisdn/basebox/blob/master/src/netlink/cnetlink.h) and [nl_bridge](https://github.com/bisdn/basebox/blob/master/src/netlink/nl_bridge.h) sub-modules to 3 and 2, respectively, simply add the following line to the configuration file:
 
 ```
 GLOG_vmodule=cnetlink=3,nl_bridge=2

--- a/index.md
+++ b/index.md
@@ -13,7 +13,7 @@ BISDN Linux Distribution is a custom Linux-based operating system for selected w
 
 * Based on Linux [yocto](https://www.yoctoproject.org/software-overview/downloads/) operating system
 * Software built on [OF-DPA 3.0](https://github.com/Broadcom-Switch/of-dpa)
-* Deployable via [Open Network Install Environment (ONIE)](http://onie.org/)
+* Deployable via [Open Network Install Environment (ONIE)](https://opencomputeproject.github.io/onie/)
 * Using [of-agent](https://github.com/Broadcom-Switch/of-dpa/tree/master/src/ofagent) as the [OpenFlow](https://www.opennetworking.org/wp-content/uploads/2014/10/openflow-switch-v1.3.5.pdf) interface
 
 ## Compatibility

--- a/network_configuration/static_routing.md
+++ b/network_configuration/static_routing.md
@@ -99,7 +99,7 @@ interface ${PORT}
 };
 ```
 
-This configuration example selects the interface where to send the advertisements on, and the prefix it should announce. The interval between each message can also be fine tuned. Further documentation on this tool can be found in [here](https://linux.die.net/man/5/radvd.conf).
+This configuration example selects the interface where to send the advertisements on, and the prefix it should announce. The interval between each message can also be fine tuned. For more information please read the official [radvd daemon man pages](https://linux.die.net/man/5/radvd.conf).
 
 Adding a static IPv6 route is done via
 

--- a/network_configuration/vlan_bridging_qinq.md
+++ b/network_configuration/vlan_bridging_qinq.md
@@ -25,7 +25,7 @@ ip link add name ${BRIDGE} type bridge vlan_filtering 1 vlan_default_pvid 1 vlan
 ip link set ${BRIDGE} up
 ```
 
-The rest of the configuration follows the same steps as the [802.1q bridging](/network_configuration/vlan_bridging.md#iproute2) section.
+The rest of the configuration follows the same steps as the [802.1q bridging](/network_configuration/vlan_bridging.html#iproute2) section.
 
 ## systemd-networkd
 
@@ -44,4 +44,4 @@ VLANFiltering=1
 VLANProtocol=802.1ad
 ```
 
-The remaining configurations follow the same steps from the instructions in the [802.1q bridging](/network_configuration/vlan_bridging.md#systemd-networkd) section.
+The remaining configurations follow the same steps from the instructions in the [802.1q bridging](/network_configuration/vlan_bridging.html#systemd-networkd) section.

--- a/network_configuration/vrrp.md
+++ b/network_configuration/vrrp.md
@@ -12,8 +12,7 @@ assignment of "virtual" IP addresses to hosts that share at least one common
 network and operate with the same virtual routed ID. On BISDN Linux this feature
 is provided by [keepalived](https://github.com/acassen/keepalived) and
 comprehensive documentation on all the available configuration options within
-keepalived can be found in the official
-[docs](https://keepalived.readthedocs.io/en/latest/configuration_synopsis.html).
+keepalived can be found in the [official keepalived docs](https://keepalived.readthedocs.io/en/latest/configuration_synopsis.html).
 
 ## VRRP configuration overview
 

--- a/network_configuration/vxlan.md
+++ b/network_configuration/vxlan.md
@@ -23,7 +23,7 @@ section as documented in
 {: .label .label-yellow }
 
 **WARNING**: The Accton AS4610 platform does not have VxLAN support. See our
-[Limitations page](/limitations.md#No-VxLAN-support-on-Accton-AS4610) for more
+[Limitations page](/limitations.html#No-VxLAN-support-on-Accton-AS4610) for more
 information.
 {: .label .label-red }
 

--- a/platform_configuration/forward_error_correction.md
+++ b/platform_configuration/forward_error_correction.md
@@ -8,7 +8,7 @@ nav_order: 3
 
 By default Broadcom switches do not enable any Forward Error Correction on ports.
 
-To enable Forward Error Correction use the [client_drivshell](tools/ofdpa_client_tools.md#client_drivshell) tool.
+To enable Forward Error Correction use the [client_drivshell](/tools/ofdpa_client_tools.md#client_drivshell) tool.
 
 There are multiple algorithms supported:
 


### PR DESCRIPTION
Several links are old (http://onie.org), do not work (pointing to .md extension instead of .html on internal pages) or are simply lacking in information in the link name itself. Update all broken links, and also add some nice explanatory text to links that go somewhere, instead of saying; 'for more information on this tool, see here'.

All fixes/updates in separate commits