### PR TITLE
use correct ipv6 documentation prefix

### DIFF
--- a/network_configuration/ospf.md
+++ b/network_configuration/ospf.md
@@ -84,7 +84,7 @@ The zebra file will configure IP addresses on the interfaces, with the configura
 interface port1
   no shutdown
   no ipv6 nd suppress-ra
-  ipv6 nd prefix 2003:db01:1::/64
+  ipv6 nd prefix 2001:db8:1::/64
 ```
 
 Regarding /etc/frr/ospf6d.conf, the configuration here must specify the point-to-point parameter in the

--- a/network_configuration/static_routing.md
+++ b/network_configuration/static_routing.md
@@ -90,7 +90,7 @@ interface ${PORT}
         AdvSendAdvert on;
         MinRtrAdvInterval 30;
         MaxRtrAdvInterval 100;
-        prefix 2003:db8:1:0::/64
+        prefix 2001:db8:1:0::/64
         {
                 AdvOnLink on;
                 AdvAutonomous on;


### PR DESCRIPTION
The documentation prefix for IPv6 is 2001:db8::/32. 2003::/19 belongs to Telekom, and shouldn't be used at all.

Fixes #67.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>