### PR TITLE
network_configuration/stp: remove warning about STP on bond

### DIFF
--- a/network_configuration/stp.md
+++ b/network_configuration/stp.md
@@ -14,9 +14,6 @@ The Spanning Tree Protocol (STP) is meant to build loop-less topologies in Layer
 **Note**: BISDN Linux ships with [mstpd](https://github.com/mstpd/mstpd) disabled. Every STP enabled bridge will use the kernel implementation of STP, and can be managed using `brctl`. If mstpd is enabled (and running), STP will be enabled and handled by mstpd in user-space on EVERY bridge created.
 {: .label .label-yellow }
 
-**WARNING**: baseboxd does not yet support STP on bonded interfaces.
-{: .label .label-yellow }
-
 ## STP Configuration Instructions
 
 The STP configuration examples below assume the following topology. Throughout all examples given here, only the switch configuration side is shown.


### PR DESCRIPTION
We support STP on bond since a while, but forgot to remove the warning when updating our docs for it, so drop it.

Fixes: e2ba1bcb9e68 ("known issues: stp now supported on bonds")
Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>