### PR TITLE
vlan_bridging: fix iproute2 example vlan trunk config

### DIFF
--- a/network_configuration/vlan_bridging.md
+++ b/network_configuration/vlan_bridging.md
@@ -170,10 +170,10 @@ ip link set port54 up
 Finally, configuring the VLANs on the bridge member ports, and the bridge itself is done with the following commands.  The self flag is required when configuring the VLAN on the bridge interface itself.
 
 ```
-bridge vlan add vid 2 dev port2 pvid
-bridge vlan add vid 3 dev port3 pvid
-bridge vlan add vid 2 dev port54 untagged
-bridge vlan add vid 3 dev port54 untagged
+bridge vlan add vid 2 dev port2 pvid untagged
+bridge vlan add vid 3 dev port3 pvid untagged
+bridge vlan add vid 2 dev port54
+bridge vlan add vid 3 dev port54
 bridge vlan add vid 2 dev swbridge self
 bridge vlan add vid 3 dev swbridge self
 ```


### PR DESCRIPTION
The example diagram and text describes VLAN 2 as untagged on port2, and VLAN 3 untagged on port3, while port54 carries both as tagged.

Therefore the untagged flag needs to be set for the access ports port2 and port3, while port54 should not be untagged at all for either vid 2 nor 3.

So fix this so the bridge commands match the description.

Fixes: 3b7791a7b4f1 ("Added example for trunk VLAN")
Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>