### PR TITLE
Update tzinfo in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ end
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
 # and associated library.
 install_if -> { RUBY_PLATFORM =~ %r!mingw|mswin|java! } do
-  gem "tzinfo", "~> 1.2"
+  gem "tzinfo", "~> 2.0"
   gem "tzinfo-data"
 end
 


### PR DESCRIPTION
The version pin on tzinfo prevents a security update of the activesupport gem, which is why dependabot says [1]:

```
Dependabot cannot update activesupport to a non-vulnerable version
The latest possible version of activesupport that can be installed is 6.0.6.1.
The earliest fixed version is 6.1.7.1.
```

Update the version pin to let dependabot do its thing.

[1] https://github.com/bisdn/bisdn.github.io/security/dependabot/15