### PR TITLE
ospfv3: update area assignment to new syntax

### DIFF
--- a/network_configuration/ospf.md
+++ b/network_configuration/ospf.md
@@ -96,10 +96,10 @@ on the router.
 interface port53
   ipv6 ospf6 mtu-ignore
   ipv6 ospf6 network point-to-point
+  ipv6 ospf6 area 10.10.10.10
 !
 router ospf6
       ospf6 router-id {{router_id}}
-      interface port53 area 10.10.10.10
       redistribute connected
 exit
 ```


### PR DESCRIPTION
Assigning ports to areas in the router block is deprecated for OSPFv3, and should be done on interface blocks instead.

Fixes warnings like:

        frrinit.sh[2372]: This command is deprecated, because it is not VRF-aware.
        frrinit.sh[2372]: Please, use "ipv6 ospf6 area" on an interface instead.