### PR TITLE
use single frr.conf for daemon configuraton in frr documentation

### DIFF
--- a/network_configuration/eigrp.md
+++ b/network_configuration/eigrp.md
@@ -19,7 +19,7 @@ Configuring EIGRP in FRR starts by activating the daemon in `/etc/frr/daemons`.
 eigrpd=yes
 ```
 
-Then `/etc/frr/eigrpd.conf` can be configured as follows.
+Then `/etc/frr/frr.conf` can be configured as follows.
 
 ```
 router eigrp 65000

--- a/network_configuration/isis.md
+++ b/network_configuration/isis.md
@@ -67,43 +67,6 @@ exchange routes for the two networks `10.0.100.2/32` and `10.0.101.2/32`
 configured on each of the loopback interfaces of the servers between all
 involved elements via IS-IS.
 
-
-`switch-1: /etc/frr/zebra.conf`
-
-```
-interface port7
-  ip address 10.0.1.1/24
-interface port54
-  ip address 10.0.0.1/24
-```
-
-`switch-2: /etc/frr/zebra.conf`
-
-```
-interface port7
-  ip address 10.0.2.1/24
-interface port54
-  ip address 10.0.0.2/24
-```
-
-`server-1: /etc/frr/zebra.conf`
-
-```
-interface eno7
-  ip address 10.0.1.2/24
-interface lo
-  ip address 10.0.100.2/32
-```
-
-`server-2: /etc/frr/zebra.conf`
-
-```
-interface eno7
-  ip address 10.0.2.2/24
-interface lo
-  ip address 10.0.101.2/32
-```
-
 To configure IS-IS between all elements shown in the topology above, we need to
 assign unique network entity titles in ISO format ("net") to all of them and
 configure which interfaces we want to use within the IS-IS routing domain. The
@@ -114,9 +77,14 @@ that the route to the /32 address configured on it will also be announced to
 all other routers.
 
 
-`switch-1: /etc/frr/isisd.conf`
+`switch-1: /etc/frr/frr.conf`
 
 ```
+interface port7
+  ip address 10.0.1.1/24
+interface port54
+  ip address 10.0.0.1/24
+
 router isis BISDN
   is-type level-1-2
   net 49.0001.0100.0100.0100.00
@@ -129,9 +97,14 @@ interface port7
   isis circuit-type level-2
 ```
 
-`switch-2: /etc/frr/isisd.conf`
+`switch-2: /etc/frr/frr.conf`
 
 ```
+interface port7
+  ip address 10.0.2.1/24
+interface port54
+  ip address 10.0.0.2/24
+
 router isis BISDN
   is-type level-1-2
   net 49.0001.0100.0100.0101.00
@@ -144,9 +117,14 @@ interface port7
   isis circuit-type level-2
 ```
 
-`server-1: /etc/frr/isisd.conf`
+`server-1: /etc/frr/frr.conf`
 
 ```
+interface eno7
+  ip address 10.0.1.2/24
+interface lo
+  ip address 10.0.100.2/32
+
 router isis BISDN
   is-type level-1-2
   net 49.0001.0200.0200.0200.0200.00
@@ -157,9 +135,14 @@ interface lo
   ip router isis BISDN
 ```
 
-`server-2: /etc/frr/isisd.conf`
+`server-2: /etc/frr/frr.conf`
 
 ```
+interface eno7
+  ip address 10.0.2.2/24
+interface lo
+  ip address 10.0.101.2/32
+
 router isis BISDN
   is-type level-1-2
   net 49.0001.0200.0200.0200.0201.00

--- a/network_configuration/ospf.md
+++ b/network_configuration/ospf.md
@@ -14,8 +14,8 @@ This section provides an overview on how to configure both versions on BISDN Lin
 
 ## OSPFv2 configuration
 
-OSPF must first be enabled in /etc/frr/daemons file. The relevant files for this test case must then be
-configured, /etc/frr/zebra.conf and /etc/frr/osfpd.conf.
+OSPF must first be enabled in /etc/frr/daemons file. The relevant file for this test case must then be
+configured, /etc/frr/frr.conf.
 
 ```
 zebra=yes
@@ -26,20 +26,19 @@ vtysh_enable=yes
 zebra_options="  -A 127.0.0.1 -s 90000000"
 ```
 
-The zebra file will set IP addresses on the interfaces with the configuration snippet. It is not required that the same tools are used, just that the system is correctly configured for the connectivity tests.
+The zebra configuration will set IP addresses on the interfaces with the configuration snippet. It is not required that the same tools are used, just that the system is correctly configured for the connectivity tests.
+
+Regarding OSPFv2, the configuration here must specify the point-to-point parameter in the
+interface specific section, to enable the protocol on the port53 link between the two Basebox routers.
+The redistribute connected command is a “smart” flag by FRR, that will redistribute every network configured
+on the router.
+
 
 ```
 interface port1
   no shutdown
   ip address 10.1.1.1/24
-```
 
-Regarding /etc/frr/osfpd.conf, the configuration here must specify the point-to-point parameter in the
-interface specific section, to enable the protocol on the port53 link between the two Basebox routers.
-The redistribute connected command is a “smart” flag by FRR, that will redistribute every network configured
-on the router.
-
-```
 interface port53
   ip ospf mtu-ignore
   ip ospf network point-to-point
@@ -65,8 +64,8 @@ ip route
 
 ## OSPFv3
 
-OSPFv3 must first be enabled in /etc/frr/daemons file. The relevant files for this test case must then be
-configured, /etc/frr/zebra.conf and /etc/frr/osfp6d.conf.
+OSPFv3 must first be enabled in /etc/frr/daemons file. The relevant file for this test case must then be
+configured, /etc/frr/frr.conf.
 
 ```
 zebra=yes
@@ -78,21 +77,19 @@ zebra_options="  -A 127.0.0.1 -s 90000000"
 ...
 ```
 
-The zebra file will configure IP addresses on the interfaces, with the configuration snippet. The following configurations allow setting up the Router neighboring discover packets and IP address auto-configuration.
+The zebra configuration will configure IP addresses on the interfaces, with the configuration snippet. The following configurations allow setting up the Router neighboring discover packets and IP address auto-configuration.
+
+Regarding OSPFv3, the configuration here must specify the point-to-point parameter in the
+interface specific section, to enable the protocol on the port53 link between the two Basebox routers.
+The redistribute connected command is a “smart” flag by FRR, that will redistribute every network configured
+on the router.
 
 ```
 interface port1
   no shutdown
   no ipv6 nd suppress-ra
   ipv6 nd prefix 2001:db8:1::/64
-```
 
-Regarding /etc/frr/ospf6d.conf, the configuration here must specify the point-to-point parameter in the
-interface specific section, to enable the protocol on the port53 link between the two Basebox routers.
-The redistribute connected command is a “smart” flag by FRR, that will redistribute every network configured
-on the router.
-
-```
 interface port53
   ipv6 ospf6 mtu-ignore
   ipv6 ospf6 network point-to-point

--- a/network_configuration/rip.md
+++ b/network_configuration/rip.md
@@ -19,7 +19,7 @@ Configuring EIGRP in FRR starts by activating the daemon in `/etc/frr/daemons`.
 ripd=yes
 ```
 
-Configuring the daemon is done via the `/etc/frr/ripd.conf`.
+Configuring the daemon is done via the `/etc/frr/frr.conf`.
 
 ```
 router rip


### PR DESCRIPTION
The use of per-daemon configuration files is deprecated for FRR, and will be removed in the future. FRR 10 already only supports reading the configuration, but not writing it anymore.

So we should not teach using per-daemon configuration files, and instead always refer to `/etc/frr/frr.conf`.

Fix up all protocol configuration documentation to use a single `frr.conf`, and reword slightly to fit the change.

In cases where both zebra and daemon specific configuration is used, move all configuration description to above the example configuration file contents.