### PR TITLE
support: add slack invite link for the next 400 users

### DIFF
--- a/support.md
+++ b/support.md
@@ -5,8 +5,9 @@ nav_order: 11
 
 # Support
 
-Get free community support in [our Slack
-community](https://baseboxd.slack.com/), or a paid commercial support plan.
+We offer free community support in
+[our Slack community](https://join.slack.com/t/baseboxd/shared_invite/zt-2z5vow4iq-3qk4vSjyLgftnBGZKhttcQ)
+channel.
 
 If you want to purchase a support contract with your BISDN Linux instance,
 please reach out to our sales team at [sales@bisdn.de](mailto:sales@bisdn.de).


### PR DESCRIPTION
* slack does not allow users to automatically join our community support channel anymore, so we have to use an invite link
* the invite link here never expires, but is only good for 400 users (which should be more than enough for now)