### PR TITLE
style: add md tags for all blocks in 802.1x docs and escape liquid tags

### DIFF
--- a/network_configuration/802.1x.md
+++ b/network_configuration/802.1x.md
@@ -72,7 +72,7 @@ BEFORE:
 
 20-port1.network:
 
-```
+```ini
 [Match]
 Name=port1
 
@@ -89,7 +89,7 @@ AFTER:
 
 20-port1.network:
 
-```
+```ini
 [Match]
 Name=port1
 
@@ -129,7 +129,7 @@ password `hello` is to uncomment those credentials in the file
 
 BEFORE:
 
-```
+```text
 # The canonical testing user which is in most of the
 # examples.
 #
@@ -140,7 +140,7 @@ BEFORE:
 
 AFTER:
 
-```
+```text
 # The canonical testing user which is in most of the
 # examples.
 #
@@ -211,7 +211,7 @@ before. For our example, the value of `$PORTNAME` is `eno2`. The content of the
 file `/etc/wpa_supplicant/wpa_supplicant-wired-eno2.conf` for our example
 scenario on the server is shown below.
 
-```
+```text
 ap_scan=0
 network={
     key_mgmt=IEEE8021X
@@ -271,7 +271,8 @@ option `compat`, radiusd will fail to start.
 
 BEFORE:
 
-```
+{% raw %}
+```text
 # -*- text -*-
 #
 #  $Id: e3f3bf568d92eba8eb17bbad590f846f2d9e1ac8 $
@@ -303,10 +304,12 @@ files {
         preproxy_usersfile = ${moddir}/pre-proxy
 }
 ```
+{% endraw %}
 
 AFTER:
 
-```
+{% raw %}
+```text
 # -*- text -*-
 #
 #  $Id: e3f3bf568d92eba8eb17bbad590f846f2d9e1ac8 $
@@ -346,6 +349,7 @@ files authorized_macs {
         usersfile = ${confdir}/authorized_macs
 }
 ```
+{% endraw %}
 
 The next file needed for MAB with freeRADIUS needs to be created at
 `/etc/raddb/authorized_macs`, like documented upstream here:
@@ -359,7 +363,7 @@ the supplicant in the function `rewrite_calling_station_id` within the
 `authorize` block to be all capital and use `-` as separator before comparing it
 to the MAC in the authorized\_macs file.
 
-```
+```text
 1A-2B-3C-4D-5F-66
         Reply-Message = "Device with MAC Address %{Calling-Station-Id} authorized for network access"
 ```
@@ -368,7 +372,7 @@ Last, but not least, we need to replace the authorization block in the
 `/etc/raddb/sites-available/default` file on our BISDN Linux switch with the
 block shown below.
 
-```
+```text
 authorize {
         preprocess
 
@@ -443,7 +447,7 @@ is the one targeting `mac_auth`. By default, this option is set to `mac_auth=0`,
 to completely disable MAC authentication bypassing. To enable MAB for our
 scenario, we need to set it to `mac_auth=1` like shown below.
 
-```
+```text
 ...
 # Enable MAC Authentication Bypass (MAB):
 # 0 = disable MAB


### PR DESCRIPTION
* mark all ini blocks as ini and all config files with undefined format as text
* use {% raw %} to mark code blocks which contain syntax which would otherwise be parsed by liquid (https://shopify.github.io/liquid/tags/template/#raw)