### PR TITLE
switch_tcpdump.md: fix link "ACL table entry management tool"

### DIFF
--- a/tools/switch_tcpdump.md
+++ b/tools/switch_tcpdump.md
@@ -17,7 +17,8 @@ traffic that is redirected within the switch ASIC to the specified port without
 passing through the Linux kernel.
 
 Internally, this is done by adding an ACL table entry matching on the desired
-port with the [ACL table entry management tool](#acl-table-entry-management)
+port with the
+[ACL table entry management tool](ofdpa_client_tools.md#ACL-table-entry-management)
 and sending its traffic to controller, capturing traffic with `tcpdump`. Once
 the capture is done, the ACL table entry is removed again.
 


### PR DESCRIPTION
Fix the broken link to "ACL table entry management tool":

- add missing file name
- fix anchor name (case-sensitive)