### PR TITLE
docs: improve code highlighting in code blocks and minor style fixes

### DIFF
--- a/network_configuration/link_aggregation.md
+++ b/network_configuration/link_aggregation.md
@@ -144,7 +144,7 @@ With these two addresses assigned, both servers should now be able to reach each
 To configure the scenario described and shown above, we first create the two bond devices themselves on both switches by creating corresponding .netdev files for systemd-networkd (to create these files, you need root privileges):
 
 `/etc/systemd/network/20-bond1.netdev`
-```
+```ini
 [NetDev]
 Name=bond1
 Kind=bond
@@ -153,7 +153,7 @@ Mode=802.3ad
 ```
 
 `/etc/systemd/network/20-bond2.netdev`
-```
+```ini
 [NetDev]
 Name=bond2
 Kind=bond
@@ -164,28 +164,28 @@ Mode=802.3ad
 To enslave the links to their corresponding bonds, we set their network configuration to match on the name of the bond we created before:
 
 `/etc/systemd/network/30-port7.network`
-```
+```ini
 [Match]
 Name=port7
 [Network]
 Bond=bond1
 ```
 `/etc/systemd/network/30-port8.network`
-```
+```ini
 [Match]
 Name=port8
 [Network]
 Bond=bond1
 ```
 `/etc/systemd/network/30-port52.network`
-```
+```ini
 [Match]
 Name=port52
 [Network]
 Bond=bond2
 ```
 `/etc/systemd/network/30-port54.network`
-```
+```ini
 [Match]
 Name=port54
 [Network]
@@ -195,12 +195,12 @@ Bond=bond2
 To allow traffic forwarding between the two bonds we created, we create a bridge and attach them to it:
 
 `/etc/systemd/network/10-swbridge.network`
-```
+```ini
 [Match]
 Name=swbridge
 ```
 `/etc/systemd/network/10-swbridge.netdev`
-```
+```ini
 [NetDev]
 Name=swbridge
 Kind=bridge
@@ -209,14 +209,14 @@ DefaultPVID=1
 VLANFiltering=1
 ```
 `/etc/systemd/network/20-bond1.network`
-```
+```ini
 [Match]
 Name=bond1
 [Network]
 Bridge=swbridge
 ```
 `/etc/systemd/network/20-bond2.network`
-```
+```ini
 [Match]
 Name=bond2
 [Network]
@@ -231,7 +231,7 @@ systemctl restart systemd-networkd
 To configure the servers, we can follow the same structure for creating the systemd-networkd configuration files:
 
 `/etc/systemd/network/20-bond1.netdev`
-```
+```ini
 [NetDev]
 Name=bond1
 Kind=bond
@@ -239,14 +239,14 @@ Kind=bond
 Mode=802.3ad
 ```
 `/etc/systemd/network/30-eno7.network`
-```
+```ini
 [Match]
 Name=eno7
 [Network]
 Bond=bond1
 ```
 `/etc/systemd/network/30-eno8.network`
-```
+```ini
 [Match]
 Name=eno8
 [Network]
@@ -256,14 +256,14 @@ Bond=bond1
 After creating all configuration on both switches and both servers with the commands shown above, we can now assign IP addresses to the bond interfaces on the servers and start pinging each other:
 
 `server-1: /etc/systemd/network/20-bond1.network`
-```
+```ini
 [Match]
 Name=bond1
 [Network]
 Address=10.0.3.1/24
 ```
 `server-2: /etc/systemd/network/20-bond1.network`
-```
+```ini
 [Match]
 Name=bond1
 [Network]

--- a/network_configuration/q-in-q-vlan-tunneling.md
+++ b/network_configuration/q-in-q-vlan-tunneling.md
@@ -85,8 +85,7 @@ can be executed on both of them without any modifications.
 Create a switch bridge named `swbridge` with no default VLAN and allow it to
 forward and filter 802.1q tagged traffic.
 
-- 10-swbridge.netdev
-
+`10-swbridge.netdev`
 ```ini
 [NetDev]
 Name=swbridge
@@ -100,8 +99,7 @@ VLANProtocol=802.1q
 
 Automatically set the switch bridge `swbridge` administrative state to up.
 
-- 10-swbridge.network
-
+`10-swbridge.network`
 ```ini
 [Match]
 Name=swbridge
@@ -110,8 +108,7 @@ Name=swbridge
 Attach `port2` to the `swbridge` and allow it to forward VLAN traffic with the
 VLAN id 12 from (and to) the server across the bridge.
 
-- 20-port2.network
-
+`20-port2.network`
 ```ini
 [Match]
 Name=port2
@@ -126,8 +123,7 @@ VLAN=12
 Automatically set `port54` (connected to another switch) up and associate it to
 the VLAN interface `port54.33`.
 
-- 10-port54.network
-
+`10-port54.network`
 ```ini
 [Match]
 Name=port54
@@ -139,8 +135,7 @@ VLAN=port54.33
 Define the VLAN interface `port54.33` on top of `port54` and allow it to tag
 (egress) and untag (ingress) traffic with an 802.1ad VLAN tag with the id 33.
 
-- 20-port54.33.netdev
-
+`20-port54.33.netdev`
 ```ini
 [NetDev]
 Name=port54.33
@@ -154,8 +149,7 @@ Protocol=802.1ad
 Attach the VLAN interface `port54.33` to the `swbridge` and allow it to forward
 VLAN traffic with the VLAN id 12 across the bridge.
 
-- 20-port54.33.network
-
+`20-port54.33.network`
 ```ini
 [Match]
 Name=port54.33
@@ -177,8 +171,7 @@ last step.
 Automatically set `eno2` (connected to the switch) up and associate it to the
 VLAN interface `eno2.12`.
 
-- 20-eno2.network
-
+`20-eno2.network`
 ```ini
 [Match]
 Name=eno2
@@ -190,8 +183,7 @@ VLAN=eno2.12
 Define the VLAN interface `eno2.12` on top of `eno2` and allow it to tag
 (egress) and untag (ingress) traffic with an 802.1q VLAN tag with the id 12.
 
-- 20-eno2.12.netdev
-
+`20-eno2.12.netdev`
 ```ini
 [NetDev]
 Name=eno2.12
@@ -207,8 +199,7 @@ Automatically set `eno2.12` up and assign the IP address `10.0.0.1` from a
 topology shown above and the IP address has to be changed to `10.0.0.2` for
 `server-2`.
 
-- 30-eno2.12.network
-
+`30-eno2.12.network`
 ```ini
 [Match]
 Name=eno2.12

--- a/network_configuration/static_routing.md
+++ b/network_configuration/static_routing.md
@@ -38,9 +38,8 @@ ip route del ${DESTINATION_NETWORK}/${DESTINATION_MASK} dev ${PORT} via ${GATEWA
 
 IPv4 routing in systemd-networkd is done using the [Network] and [Route] sections to the port .network file. In the [Route] section, the Gateway= section *must* be present in the case when DHCP is not used.
 
-```
-10-port1.network:
-
+`10-port1.network`
+```ini
 [Match]
 Name=${PORT}
 
@@ -151,7 +150,7 @@ The port ``eno2`` on each server is connected to ``port2`` on its respective swi
 Set ``port2`` up and add the IP address 10.0.1.1/24.
 
 `switch-1 /etc/systemd/network/30-port2.network`
-```
+```ini
 [Match]
 Name=port2
 [Network]
@@ -161,7 +160,7 @@ Address=10.0.1.1/24
 Set ``port54`` up, add IP address 10.0.3.1 and add a route to the 10.0.2.0/24 subnet (which is on ``server-2``) via 10.0.3.2.
 
 `switch-1 /etc/systemd/network/30-port54.network`
-```
+```ini
 [Match]
 Name=port54
 [Network]
@@ -176,7 +175,7 @@ Gateway=10.0.3.2
 Set ``port2`` up and add IP address 10.0.2.1/24.
 
 `switch-2 /etc/systemd/network/30-port2.network`
-```
+```ini
 [Match]
 Name=port2
 [Network]
@@ -186,7 +185,7 @@ Address=10.0.2.1/24
 Set ``port54`` up, add IP address 10.0.3.2 and add a route to the 10.0.1.0/24 subnet (which is on ``sever-1``) via 10.0.3.1.
 
 `switch-2 /etc/systemd/network/30-port54.network`
-```
+```ini
 [Match]
 Name=port54
 [Network]
@@ -201,7 +200,7 @@ Gateway=10.0.3.1
 Add IP address 10.0.1.2/24 to ``eno2`` and a route to the subnet 10.0.2.0/24 (which is on ``server-2``) via 10.0.1.1.
 
 `server-1 /etc/systemd/network/30-eno2.network`
-```
+```ini
 [Match]
 Name=eno2
 [Network]
@@ -216,7 +215,7 @@ Gateway=10.0.1.1
 Add IP address 10.0.2.2/24 to ``eno2`` and a route to the subnet 10.0.1.0/24 (which is on ``server-1``) via 10.0.2.1.
 
 `server-2 /etc/systemd/network/30-eno2.network`
-```
+```ini
 [Match]
 Name=eno2
 [Network]

--- a/network_configuration/stp.md
+++ b/network_configuration/stp.md
@@ -27,9 +27,9 @@ ip link add name swbridge type bridge vlan_filtering 1 stp_state 1
 ```
 
 or by copying following systemd-networkd configuration files into the /etc/systemd/network directory and restarting the `systemd-networkd` systemd-service.
-```
-10-swbridge.netdev:
 
+`10-swbridge.netdev`
+```ini
 [NetDev]
 Name=swbridge
 Kind=bridge
@@ -39,9 +39,8 @@ VLANFiltering=1
 STP=1
 ```
 
-```
-10-swbridge.network:
-
+`10-swbridge.network`
+```ini
 [Match]
 Name=swbridge
 ```
@@ -52,7 +51,7 @@ The necessary commands for configuring and attaching the ports to the bridge are
 
 We can see the ports that are configured in bridges, along with their STP state, priority, and cost, with the following command:
 
-```
+```bash
 agema-ag4610:~$ bridge link
 15: port2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 master swbridge state forwarding priority 32 cost 2
 16: port3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 master swbridge state forwarding priority 32 cost 2
@@ -61,7 +60,7 @@ agema-ag4610:~$ bridge link
 After setting up the bridge and bridge ports, the STP state on the bridge can be managed over the `brctl` utility. A complete reference can be found on the [brctl man page](https://linux.die.net/man/8/brctl).
 The following example shows the output of a `brctl` command:
 
-```
+```bash
 agema-ag4610:/home/basebox# brctl showstp swbridge
 swbridge
  bridge id              8000.62e79c6a4489
@@ -108,7 +107,7 @@ mstpd is managed by systemd and is disabled by default. For documentation on how
 
 When `mstpd` is running, any stp enabled bridge will be managed by mstpd. By default it uses RSTP.
 
-```
+```bash
 ip link add name swbridge type bridge vlan_filtering 1 stp_state 1
 ```
 
@@ -122,7 +121,7 @@ After setting up the bridge and its ports, the RSTP state on the bridge can be m
 **WARNING**: The `brctl` tool does not work with bridges managed by `mstpd`. Use `mstpctl` instead.
 {: .label .label-yellow }
 
-```
+```bash
 agema-ag4610:/home/basebox# mstpctl showbridge
 swbridge CIST info
   enabled         yes
@@ -143,7 +142,7 @@ swbridge CIST info
   last topology change port  port7
 ```
 
-```
+```bash
 agema-ag4610:/home/basebox# mstpctl showport swbridge port7
    port7 8.001 forw 2.000.6E:F8:F4:3D:E3:D7 2.000.6E:F8:F4:3D:E3:D7 8.001 Desg
 agema-ag461-:/home/basebox# mstpctl showport swbridge port8
@@ -177,7 +176,7 @@ bridge to mstp (instead of "rstp", which would be used by default when mstpd is
 managing the bridge). Assuming your bridge is named "swbridge", this can be done
 by running:
 
-```
+```bash
 root@accton-as4610:~# mstpctl setforcevers swbridge mstp
 root@accton-as4610:~# mstpctl showbridge swbridge
 swbridge CIST info
@@ -207,7 +206,7 @@ VLANs you want to mange in them and can be choosen in the range between 1-65,
 while 0 is already created by default to manage all VLANs not mapped to any
 other tree).
 
-```
+```bash
 root@accton-as4610:~# mstpctl showmstilist swbridge
 swbridge list of known MSTIs:
  0
@@ -224,12 +223,12 @@ the id of the VLAN), which will then in turn each be assigned to an mstid.
 
 Mapping FID to VID (please make sure to put FID and VID in the correct order):
 
-```
+```bash
 Usage: mstpctl setvid2fid <bridge> <FID>:<VIDs List> [<FID>:<VIDs List> ...]
   Set VIDs-to-FIDs allocation
 ```
 
-```
+```bash
 root@accton-as4610:~# mstpctl showvid2fid swbridge
 swbridge VID-to-FID allocation table:
   FID 0: 1-4094
@@ -244,12 +243,12 @@ swbridge VID-to-FID allocation table:
 
 Mapping MSTID to FID (please make sure to put MSTID and FID in the correct order):
 
-```
+```bash
 Usage: mstpctl setfid2mstid <bridge> <mstid>:<FIDs List> [<mstid>:<FIDs List> ...]
   Set FIDs-to-MSTIDs allocation
 ```
 
-```
+```bash
 root@accton-as4610:~# mstpctl showfid2mstid swbridge
 swbridge FID-to-MSTID allocation table:
   MSTID 0: 0-4095
@@ -270,7 +269,7 @@ bridge) are the same on all switches within that MST region. If you configured
 multiple switches with the commands shown above, your configuration might look
 similar to this ("Configuration Name" will be different for you):
 
-```
+```bash
 root@accton-as4610-1:~# mstpctl showmstconfid swbridge
 swbridge MST Configuration Identifier:
   Format Selector:      0
@@ -279,7 +278,7 @@ swbridge MST Configuration Identifier:
   Configuration Digest: 8A9442199657EA49D1124EA768B5D9A2
 ```
 
-```
+```bash
 root@accton-as4610-2:~# mstpctl showmstconfid swbridge
 swbridge MST Configuration Identifier:
   Format Selector:      0
@@ -292,7 +291,7 @@ To place both switches in the same MST region, you can set the "Configuration
 Names" on all switches to e.g. "12345" by running (where "1" is the "Revision
 Level" here):
 
-```
+```bash
 root@accton-as4610-1/2:~# mstpctl showmstconfid swbridge
 root@accton-as4610-1/2:~# mstpctl setmstconfid swbridge 1 12345
 root@accton-as4610-1/2:~# mstpctl showmstconfid swbridge

--- a/network_configuration/switch_virtual_interfaces.md
+++ b/network_configuration/switch_virtual_interfaces.md
@@ -11,7 +11,7 @@ Extending the layer 2 domain to a layer 3 routed network can be done via the Swi
 
 ## iproute2
 
-```
+```bash
 # add a link to the previously created bridge with the same VLAN as PORTX
 ip link add link ${BRIDGE} name ${BRIDGE}.${BR_VLAN} type vlan id ${BR_VLAN}
 
@@ -24,7 +24,7 @@ ip link set ${BRIDGE}.${BR_VLAN} up
 
 The IP address for this interface can then be set with.
 
-```
+```bash
 ip address add ${SVI_IP} dev ${BRIDGE}.${BR_VLAN}
 ```
 
@@ -32,9 +32,8 @@ ip address add ${SVI_IP} dev ${BRIDGE}.${BR_VLAN}
 
 The corresponding systemd-networkd configuration adds the [Network] section on the swbridge.network file:
 
-```
-10-swbridge.network:
-
+`10-swbridge.network`
+```ini
 [Match]
 Name=swbridge
 
@@ -48,9 +47,8 @@ VLAN=swbridge.10
 
 The interface swbridge.10 also has a .netdev and .network pair of files.
 
-```
-20-swbridge10.netdev:
-
+`20-swbridge10.netdev`
+```ini
 [NetDev]
 Name=swbridge.10
 Kind=vlan
@@ -66,5 +64,3 @@ Name=swbridge.10
 [Network]
 Address=10.0.10.1/24
 ```
-
-

--- a/network_configuration/virtual_routing_and_forwarding.md
+++ b/network_configuration/virtual_routing_and_forwarding.md
@@ -23,14 +23,14 @@ VRF can be configured using either [iproute2](#iproute2) or [systemd-networkd](#
 
 The creation of VRF interfaces is done via the following commands.
 
-```
+```bash
 ip link add ${VRF} type vrf table ${VRF_TABLE_ID}
 ip link set ${VRF} up
 ```
 
 After creation of the VRF device, follow the steps under Switch VLAN Interface (SVI) to configure a VLAN-aware bridge with the corresponding SVI layer 3 devices. Enslaving these links on the bridge to the VRF is possible with the below commands.
 
-```
+```bash
 ip link set ${BRIDGE}.${BR_VLAN} vrf ${VRF}
 ip link set ${BRIDGE}.${BR_VLAN2} vrf ${VRF}
 ```
@@ -41,8 +41,8 @@ Adding IP addresses to the enslaved SVIs must be done after enslavement to the V
 
 The file responsible to create the VRF device is the .netdev file below:
 
-```
-10-red.netdev
+`10-red.netdev`
+```ini
 [NetDev]
 Name=red
 Kind=vrf
@@ -53,8 +53,8 @@ TableId=10
 
 Considering the example topology given above, two SVIs are required, i.e. one per VLAN. Both need to be listed in the bridge network file:
 
-```
-10-swbridge.network
+`10-swbridge.network`
+```ini
 [Match]
 Name=swbridge
 
@@ -69,16 +69,18 @@ VLAN=swbridge.20
 
 Each SVI needs to be specified by creating a .netdev and a .network file. The following example assigns IP 10.0.10.2 to a SVI using VID 10 and VRF entry "red":
 
-```
-20-swbridge10.netdev
+`20-swbridge10.netdev`
+```ini
 [NetDev]
 Name=swbridge.10
 Kind=vlan
 
 [VLAN]
 Id=10
+```
 
-20-swbridge10.network
+`20-swbridge10.network`
+```ini
 [Match]
 Name=swbridge.10
 
@@ -89,16 +91,18 @@ VRF=red
 
 Similarly, a SVI is created for VID 20:
 
-```
-20-swbridge20.netdev
+`20-swbridge20.netdev`
+```ini
 [NetDev]
 Name=swbridge.20
 Kind=vlan
 
 [VLAN]
 Id=20
+```
 
-20-swbridge20.network
+`20-swbridge20.network`
+```ini
 [Match]
 Name=swbridge.20
 
@@ -109,8 +113,8 @@ VRF=red
 
 As a last step on the switch, ports 2 and 3 need to be added to the bridge. This is done by creating a .network file for each port:
 
-```
-20-port2.network
+`20-port2.network`
+```ini
 [Match]
 Name=port2
 
@@ -119,8 +123,10 @@ Bridge=swbridge
 
 [BridgeVLAN]
 VLAN=10
+```
 
-20-port3.network
+`20-port3.network`
+```ini
 [Match]
 Name=port3
 
@@ -133,6 +139,6 @@ VLAN=20
 
 This configuration is then applied and persisted after restarting systemd-networkd:
 
-```
+```bash
 sudo systemctl restart systemd-networkd
 ```

--- a/network_configuration/vlan_bridging.md
+++ b/network_configuration/vlan_bridging.md
@@ -43,7 +43,7 @@ Similarly to 802.1q bridging, it is possible to configure 802.1ad VLANs using
 
 Bridge creation is done with the following command:
 
-```
+```bash
 BRIDGE=${BRIDGE:-swbridge}
 ...
 ip link add name ${BRIDGE} type bridge vlan_filtering 1 vlan_default_pvid 1
@@ -59,7 +59,7 @@ default PVID and configure no VLANs on ports by default.
 To enslave interfaces to bridges refer to the following commands. The management
 interface should not be bridged with the rest of the baseboxd interfaces.
 
-```
+```bash
 # port A
 ip link set ${PORTA} master ${BRIDGE}
 ip link set ${PORTA} up
@@ -72,13 +72,13 @@ ip link set ${PORTB} up
 Configuring the VLANs on the bridge member ports is done with the following
 command
 
-```
+```bash
 bridge vlan add vid ${vid} dev ${PORTA}
 ```
 
 While removing VLANs from ports is handled via the subsequent
 
-```
+```bash
 bridge vlan del vid ${vid} dev ${PORTA}
 ```
 
@@ -90,19 +90,19 @@ assigned when configured.
 When configuring further VLANs on the bridge interface the `self` flag is
 required
 
-```
+```bash
 bridge vlan add vid ${vid} dev ${BRIDGE} self
 ```
 
 While removing VLANs works like other ports
 
-```
+```bash
 bridge vlan del vid ${vid} dev ${BRIDGE}
 ```
 
 Finally, detaching the ports from the bridge is done via
 
-```
+```bash
 ip link set ${PORTA} nomaster
 ```
 
@@ -110,7 +110,7 @@ ip link set ${PORTA} nomaster
 
 Creation of the 802.1ad bridge is done with the following commands.
 
-```
+```bash
 BRIDGE=${BRIDGE:-swbridge}
 ...
 ip link add name ${BRIDGE} type bridge vlan_filtering 1 vlan_default_pvid 1 vlan_protocol 802.1ad
@@ -127,9 +127,8 @@ The rest of the configuration follows the same steps as shown above for the
 The configuration with systemd-networkd can be done with the following files,
 under the /etc/systemd/network directory.
 
-```
-10-swbridge.netdev:
-
+`10-swbridge.netdev`
+```ini
 [NetDev]
 Name=swbridge
 Kind=bridge
@@ -151,9 +150,8 @@ used.
 The bridge interface needs to be brought up for basic bridging functionality, so
 a basic .network file is required for the bridge itself.
 
-```
-10-swbridge.network:
-
+`10-swbridge.network`
+```ini
 [Match]
 Name=swbridge
 ```
@@ -161,9 +159,8 @@ Name=swbridge
 Attaching ports to the bridge and configuring VLANs with systemd-networkd is
 also done using .network files. The following example demonstrates how.
 
-```
-20-port1.network:
-
+`20-port1.network`
+```ini
 [Match]
 Name=port1
 
@@ -186,9 +183,8 @@ value.
 Configuring VLANs on the bridge interface itself is done similarily extending
 the above .network file with a `[BridgeVLAN]` block.
 
-```
-10-swbridge.network:
-
+`10-swbridge.network`
+```ini
 [Match]
 Name=swbridge
 
@@ -205,9 +201,8 @@ containing the device type (bridge) and its configurations. Specifically related
 to 802.1ad, we configure the bridge VLAN protocol with the `VLANProtocol`
 attribute:
 
-```
-10-swbridge.netdev
-
+`10-swbridge.netdev`
+```ini
 [NetDev]
 Name=swbridge
 Kind=bridge
@@ -255,7 +250,7 @@ environments.
 
 Bridge creation is done with the following command.
 
-```
+```bash
 ip link add name swbridge type bridge vlan_filtering 1 vlan_default_pvid 0
 ip link set swbridge up
 ```
@@ -265,9 +260,9 @@ disabled. Since the ports in our example will have different PVIDs, we will
 set the bridge's default PVID to none. Only in the case where all ports have
 the same PVID, should one set the default PVID on the bridge.
 
-```
+```bash
 # port2
-ip link set port2 master swbridge 
+ip link set port2 master swbridge
 ip link set port2 up
 
 # port3
@@ -282,7 +277,7 @@ ip link set port54 up
 Finally, configuring the VLANs on the bridge member ports is done with the
 following commands.
 
-```
+```bash
 bridge vlan add vid 2 dev port2 pvid untagged
 bridge vlan add vid 3 dev port3 pvid untagged
 bridge vlan add vid 2 dev port54
@@ -290,7 +285,8 @@ bridge vlan add vid 3 dev port54
 ```
 
 Removing the configuration can be done with a reboot, or by deleting the bridge.
-```
+
+```bash
 ip link del swbridge
 ```
 
@@ -303,9 +299,8 @@ is the file name.
 The first file creates the bridge without any default PVID configured,
 analogous to ``iproute2``
 
-```
-10-swbridge.netdev:
-
+`10-swbridge.netdev`
+```ini
 [NetDev]
 Name=swbridge
 Kind=bridge
@@ -317,18 +312,16 @@ DefaultPVID=none
 
 Bring up the bridge, so forwarding will be enabled
 
-```
-10-swbridge.network:
-
+`10-swbridge.network`
+```ini
 [Match]
 Name=swbridge
 ```
 
 Attaching the access ports ``port2`` and ``port3`` is done as follows
 
-```
-20-port2.network:
-
+`20-port2.network`
+```ini
 [Match]
 Name=port2
 
@@ -340,9 +333,8 @@ PVID=2
 EgressUntagged=2
 ```
 
-```
-20-port3.network:
-
+`20-port3.network`
+```ini
 [Match]
 Name=port3
 
@@ -360,9 +352,8 @@ systemd.network](https://www.freedesktop.org/software/systemd/man/systemd.networ
 
 The trunk port is created with the following network file.
 
-```
-20-port54.network:
-
+`20-port54.network`
+```ini
 [Match]
 Name=port54
 

--- a/network_configuration/vxlan.md
+++ b/network_configuration/vxlan.md
@@ -14,7 +14,7 @@ The official VXLAN documentation can be found in
 
 **WARNING**: baseboxd does not yet support multicast groups for establishing
 communication among multiple VXLAN Tunnel Endpoints (VTEPs), only unicast is
-supported. This means you can not use the ``group`` key in the ``VXLAN``
+supported. This means you can not use the `group` key in the `VXLAN`
 section as documented in
 [systemd-netdev](https://www.freedesktop.org/software/systemd/man/systemd.netdev.html#Group=)
 {: .label .label-yellow }
@@ -52,15 +52,17 @@ information.
 ```
 
 The configuration give below will create a VXLAN overlay with VNI=50000 between
-``port54`` on ``switch-1`` and ``port54`` on ``switch-2``. The layer 2 domain containing ``port2`` and ``port2`` bridged on the swbridge on switch-1 and switch-2 is extended via the before mentioned VXLAN overlay network with the VNI 50000.
+`port54` on `switch-1` and `port54` on `switch-2`. The layer 2 domain containing
+`port2` and `port2` bridged on the swbridge on switch-1 and switch-2 is extended
+via the before mentioned VXLAN overlay network with the VNI 50000.
 
 ## systemd-networkd
 The configuration with systemd-networkd can be done with the following files.
 
-Create bridge ``swbridge`` with no ``DefaultPVID``.
+Create bridge `swbridge` with no `DefaultPVID`.
 
 `switch-1 /etc/systemd/network/20-swbridge.netdev`
-```
+```ini
 [NetDev]
 Name=swbridge
 Kind=bridge
@@ -70,10 +72,10 @@ VLANFiltering=1
 DefaultPVID=none
 ```
 
-Tag ``swbridge`` with ``VLAN=300`` and set it up.
+Tag `swbridge` with `VLAN=300` and set it up.
 
 `switch-1 /etc/systemd/network/20-swbridge.network`
-```
+```ini
 [Match]
 Name=swbridge
 
@@ -81,10 +83,11 @@ Name=swbridge
 VLAN=300
 ```
 
-Add VLAN tag ``VLAN=300`` on ``port2`` incoming traffic, untag the outgoing one, attach it to ``swbridge`` and set it up.
+Add VLAN tag `VLAN=300` on `port2` incoming traffic, untag the outgoing one,
+attach it to `swbridge` and set it up.
 
 `switch-1 /etc/systemd/network/10-port2.network`
-```
+```ini
 [Match]
 Name=port2
 
@@ -96,10 +99,11 @@ PVID=300
 EgressUntagged=300
 ```
 
-Add ip address 192.168.0.1/24 to ``port54``, define it as underlying interface for netdev vxlan50000 (created below) and set it up.
+Add ip address 192.168.0.1/24 to `port54`, define it as underlying interface for
+netdev vxlan50000 (created below) and set it up.
 
 `switch-1 /etc/systemd/network/10-port54.network`
-```
+```ini
 [Match]
 Name=port54
 
@@ -108,11 +112,11 @@ VXLAN=vxlan50000
 Address=192.168.0.1/24
 ```
 
-Create netdev ``vxlan50000`` for VXLAN with the VNI 50000 and set local and remote VXLAN Tunnel
-Endpoints(VTEPs).
+Create netdev `vxlan50000` for VXLAN with the VNI 50000 and set local and remote
+VXLAN Tunnel Endpoints(VTEPs).
 
 `switch-1 /etc/systemd/network/300-vxlan50000.netdev`
-```
+```ini
 [NetDev]
 Name=vxlan50000
 Kind=vxlan
@@ -124,19 +128,19 @@ Local=192.168.0.1
 Remote=192.168.0.2
 ```
 
-Forward VLAN tagged traffic with ``VLAN=300`` on ``vxlan50000`` and attach it to
-``swbridge``. Bind ``port54`` as the carrier device to align the behaviour and
-state (up/down) of ``vxlan50000`` to its underlying interface.
-``DestinationPort=4789`` sets the destination UDP port to follow the IANA standard
+Forward VLAN tagged traffic with `VLAN=300` on `vxlan50000` and attach it to
+`swbridge`. Bind `port54` as the carrier device to align the behaviour and
+state (up/down) of `vxlan50000` to its underlying interface.
+`DestinationPort=4789` sets the destination UDP port to follow the IANA standard
 from [rfc7348](https://datatracker.ietf.org/doc/html/rfc7348). If no port is
 set systemd will use the default Linux kernel value 8472.
 
 **WARNING**: baseboxd currently sets the local VTEP Termination port to 4789,
-which means that every remote VTEP must use ``DestinationPort``=4789.
+which means that every remote VTEP must use `DestinationPort=4789`.
 {: .label .label-yellow }
 
 `switch-1 /etc/systemd/network/300-vxlan50000.network`
-```
+```ini
 [Match]
 Name=vxlan50000
 
@@ -148,12 +152,12 @@ Bridge=swbridge
 VLAN=300
 ```
 
-The configuration files for ``switch2`` are identical to those of ``switch1``
+The configuration files for `switch2` are identical to those of `switch1`
 with the execption that the IPv4 addresses for the VTEP, Remote and Local will
 switch. Therefore the files below are shown without additional explanation.
 
 `switch-2 /etc/systemd/network/20-swbridge.netdev`
-```
+```ini
 [NetDev]
 Name=swbridge
 Kind=bridge
@@ -164,7 +168,7 @@ DefaultPVID=none
 ```
 
 `switch-2 /etc/systemd/network/20-swbridge.network`
-```
+```ini
 [Match]
 Name=swbridge
 
@@ -173,7 +177,7 @@ VLAN=300
 ```
 
 `switch-2 /etc/systemd/network/10-port2.network`
-```
+```ini
 [Match]
 Name=port2
 
@@ -186,7 +190,7 @@ EgressUntagged=300
 ```
 
 `switch-2 /etc/systemd/network/10-port54.network`
-```
+```ini
 [Match]
 Name=port54
 
@@ -196,7 +200,7 @@ Address=192.168.0.2/24
 ```
 
 `switch-2 /etc/systemd/network/300-vxlan50000.netdev`
-```
+```ini
 [NetDev]
 Name=vxlan50000
 Kind=vxlan
@@ -209,7 +213,7 @@ Remote=192.168.0.1
 ```
 
 `switch-2 /etc/systemd/network/300-vxlan50000.network`
-```
+```ini
 [Match]
 Name=vxlan50000
 


### PR DESCRIPTION
* add ini as code block style for the networkd configs i found
* align the style of how the associated file names are shown (should make it easier to copy them)
* while at it, mark other code blocks as bash
* other minor style fixes (line length, highlighting, formatting) here and there to improve the general style